### PR TITLE
separate client and main dialog

### DIFF
--- a/src/lib/y2partitioner/clients/main.rb
+++ b/src/lib/y2partitioner/clients/main.rb
@@ -1,13 +1,9 @@
 require "cwm/tree_pager"
 require "y2partitioner/device_graphs"
-require "y2partitioner/widgets/overview"
-require "y2partitioner/device_graphs"
+require "y2partitioner/dialogs/main"
 require "y2storage"
 
-Yast.import "CWM"
 Yast.import "Popup"
-Yast.import "Stage"
-Yast.import "Wizard"
 
 # Work around YARD inability to link across repos/gems:
 # (declaring macros here works because YARD sorts by filename size(!))
@@ -17,14 +13,12 @@ Yast.import "Wizard"
 # @!macro [new] seeCustomWidget
 #   @see http://www.rubydoc.info/github/yast/yast-yast2/CWM%2FCustomWidget:${0}
 
-# The main module for this package
 module Y2Partitioner
   # YaST "clients" are the CLI entry points
   module Clients
-    # Main entry point to see partitioner configuration
+    # The entry point for starting partitioner on its own. Use probed and staging device graphs.
     class Main
       extend Yast::I18n
-      extend Yast::UIShortcuts
       extend Yast::Logger
 
       # Run the client
@@ -33,29 +27,15 @@ module Y2Partitioner
         textdomain "storage"
 
         smanager = Y2Storage::StorageManager.instance
-        system = smanager.y2storage_probed
-        current = smanager.y2storage_staging
-        DeviceGraphs.create_instance(system, current)
-
-        Yast::Wizard.CreateDialog unless Yast::Stage.initial
-        res = nil
-        loop do
-          contents = MarginBox(
-            0.5,
-            0.5,
-            Widgets::OverviewTreePager.new(DeviceGraphs.instance.current)
-          )
-          res = Yast::CWM.show(contents, caption: _("Partitioner"), skip_store_for: [:redraw])
-          break if res != :redraw
-        end
+        dialog = Dialogs::Main.new
+        res = dialog.run(smanager.y2storage_probed, smanager.y2storage_staging)
 
         # Running system: presenting "Expert Partitioner: Summary" step now
         # ep-main.rb SummaryDialog
         if res == :next && should_commit?(allow_commit)
-          smanager.staging = DeviceGraphs.instance.current
+          smanager.staging = dialog.device_graph
           smanager.commit
         end
-        Yast::Wizard.CloseDialog unless Yast::Stage.initial
       end
 
       # Ask whether to proceed with changing the disks;

--- a/src/lib/y2partitioner/dialogs/main.rb
+++ b/src/lib/y2partitioner/dialogs/main.rb
@@ -1,0 +1,51 @@
+require "yast"
+require "cwm/dialog"
+require "y2partitioner/device_graphs"
+require "y2partitioner/widgets/overview"
+
+module Y2Partitioner
+  module Dialogs
+    # main entry point to partitioner showing tree pager with all content
+    class Main < CWM::Dialog
+      # @return [Y2Storage::DeviceGraph] device graph with all changes done in dialog
+      attr_reader :device_graph
+
+      def initialize
+        textdomain "storage"
+      end
+
+      def title
+        _("Partitioner")
+      end
+
+      def contents
+        MarginBox(
+            0.5,
+            0.5,
+            Widgets::OverviewTreePager.new(DeviceGraphs.instance.current)
+          )
+      end
+
+      def skip_store_for
+        [:redraw]
+      end
+
+      # runs dialog.
+      # @param system [Y2Storage::DeviceGraph] system graph used to detect if something
+      # is going to be formatted
+      # @param initial [Y2Storage::DeviceGraph] device graph to display
+      # @return [Symbol] result of dialog
+      def run(system, initial)
+        DeviceGraphs.create_instance(system, initial)
+        res = nil
+        loop do
+          res = super()
+          break if res != :redraw
+        end
+        @device_graph = DeviceGraphs.instance.current
+
+        res
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/dialogs/main.rb
+++ b/src/lib/y2partitioner/dialogs/main.rb
@@ -20,10 +20,10 @@ module Y2Partitioner
 
       def contents
         MarginBox(
-            0.5,
-            0.5,
-            Widgets::OverviewTreePager.new(DeviceGraphs.instance.current)
-          )
+          0.5,
+          0.5,
+          Widgets::OverviewTreePager.new(DeviceGraphs.instance.current)
+        )
       end
 
       def skip_store_for

--- a/test/clients/main_test.rb
+++ b/test/clients/main_test.rb
@@ -14,18 +14,6 @@ describe Y2Partitioner::Clients::Main do
       Y2Storage::StorageManager.create_test_instance
     end
 
-    it "opens wizard outside of initial stage" do
-      expect(Yast::Wizard).to receive(:OpenDialog)
-      allow(Yast::Stage).to receive(:initial).and_return(false)
-
-      subject.run
-
-      expect(Yast::Wizard).to_not receive(:OpenDialog)
-      allow(Yast::Stage).to receive(:initial).and_return(true)
-
-      subject.run
-    end
-
     describe "when committing is allowed" do
       it "asks, and commits when confirmed" do
         smanager = Y2Storage::StorageManager.instance


### PR DESCRIPTION
- [x] adapt yast2-storage-ng ( not needed, is independent )
- [x] test installation with new one ( not needed, is independent )
- [x] test runtime with this change

it requires change also in yast-storage-ng and testing it, if it works well.


