### PR TITLE
Ask for confirmation before aborting in installation

### DIFF
--- a/package/yast2-partitioner.changes
+++ b/package/yast2-partitioner.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Sat Jul  8 05:23:53 UTC 2017 - ancor@suse.com
+
+- During installation, ask for confirmation before aborting.
+
+-------------------------------------------------------------------
 Mon Jul  3 11:08:49 UTC 2017 - jreidinger@suse.com
 
 - add deletion of disks and also more complex confirm if there are

--- a/src/lib/y2partitioner/dialogs/main.rb
+++ b/src/lib/y2partitioner/dialogs/main.rb
@@ -3,6 +3,9 @@ require "cwm/dialog"
 require "y2partitioner/device_graphs"
 require "y2partitioner/widgets/overview"
 
+Yast.import "Mode"
+Yast.import "Popup"
+
 module Y2Partitioner
   module Dialogs
     # main entry point to partitioner showing tree pager with all content
@@ -40,7 +43,13 @@ module Y2Partitioner
         res = nil
         loop do
           res = super()
-          break if res != :redraw
+
+          next if res == :redraw
+          if res == :abort && Yast::Mode.installation
+            next unless Yast::Popup.ConfirmAbort(:painless)
+          end
+
+          break
         end
         @device_graph = DeviceGraphs.instance.current
 


### PR DESCRIPTION
All the dialogs offering an 'abort' button during installation must ask for confirmation (it cannot be done outside the dialog because there would be no way to return to the same point if the dialog already returned).