### PR TITLE
Use BlkDevice#basename and don't monkey patch

### DIFF
--- a/src/clients/partitioner_testing.rb
+++ b/src/clients/partitioner_testing.rb
@@ -5,20 +5,6 @@ require "yast"
 require "y2partitioner/clients/main"
 require "y2storage"
 
-# fake sysfs_name method as loading it from yaml is not supported and for xml
-# I did not find complex enough examples
-
-module Y2Storage
-  # just reopening for faking up sysfs_name
-  # not production code, only for testing
-  class BlkDevice < Device
-    # @return [String] "sda2" or "dm-1"
-    def sysfs_name
-      name.split("/").last
-    end
-  end
-end
-
 arg = Yast::WFM.Args.first
 case arg
 when /.ya?ml$/

--- a/src/lib/y2partitioner/widgets/disk_bar_graph.rb
+++ b/src/lib/y2partitioner/widgets/disk_bar_graph.rb
@@ -24,7 +24,7 @@ module Y2Partitioner
         end
 
         partitions = @disk.partitions.map do |part|
-          [part.region, part.sysfs_name]
+          [part.region, part.basename]
         end
 
         (free_regions + partitions).sort_by { |i| i[0].start }

--- a/src/lib/y2partitioner/widgets/disk_page.rb
+++ b/src/lib/y2partitioner/widgets/disk_page.rb
@@ -28,7 +28,7 @@ module Y2Partitioner
 
       # @macro seeAbstractWidget
       def label
-        disk.sysfs_name
+        disk.basename
       end
 
       # @macro seeCustomWidget

--- a/test/widgets/disk_page_test.rb
+++ b/test/widgets/disk_page_test.rb
@@ -7,7 +7,7 @@ describe Y2Partitioner::Widgets::DiskPage do
   let(:pager) { double("Pager") }
   let(:disk) do
     double("Disk",
-      name: "mydisk", sysfs_name: "sysmydisk",
+      name: "mydisk", basename: "sysmydisk",
       partitions: [], partition_table: partition_table)
   end
   let(:partition_table) do


### PR DESCRIPTION
`BlkDevice#basename` returns something meaningful for both preexisting and newly created (not yet in system) devices. Using `BlkDevice#sysfs_name` leaded to some blank spaces in the UI during installation or real stand-alone execution of the partitioner.

Removed monkey-patching, since, as can [be seen here](https://github.com/yast/yast-storage-ng/blob/master/src/lib/y2storage/blk_device.rb#L232), the monkey-patch contained identical implementation than `#basename`.