### PR TITLE
Format and Mount: Fstab Options, many other changes

### DIFF
--- a/package/yast2-partitioner.changes
+++ b/package/yast2-partitioner.changes
@@ -1,4 +1,19 @@
 -------------------------------------------------------------------
+Tue Jul 11 09:21:23 UTC 2017 - knut.anderssen@suse.com
+
+- Add Partition sequence
+  - skip Partition Type choice if only one is possible
+  - added the Partition Role step
+  - added the Ecryption Password step (optional)
+  - do not allow a filesystem in an extended partition
+- Format and Mount dialog:
+  - implemented the Fstab Options pop-up
+  - set default fstab options for the filesystem selected
+  - offer only the filesystems allowed for a specific partition id
+  - do not allow formatting if not appropriate
+- 3.3.8
+
+-------------------------------------------------------------------
 Sat Jul  8 05:23:53 UTC 2017 - ancor@suse.com
 
 - During installation, ask for confirmation before aborting.

--- a/package/yast2-partitioner.spec
+++ b/package/yast2-partitioner.spec
@@ -16,7 +16,7 @@
 #
 
 Name:		yast2-partitioner
-Version:        3.3.7
+Version:        3.3.8
 Release:	0
 BuildArch:	noarch
 

--- a/package/yast2-partitioner.spec
+++ b/package/yast2-partitioner.spec
@@ -26,10 +26,10 @@ Source:		%{name}-%{version}.tar.bz2
 # CWM::Dialog
 Requires:	yast2 >= 3.2.40
 Requires:	yast2-ruby-bindings
-Requires:	yast2-storage-ng >= 0.1.29
+Requires:	yast2-storage-ng >= 0.1.30
 
 BuildRequires:	update-desktop-files
-BuildRequires:	yast2-storage-ng >= 0.1.29
+BuildRequires:	yast2-storage-ng >= 0.1.30
 BuildRequires:	yast2-ruby-bindings
 BuildRequires:	yast2-devtools
 BuildRequires:	yast2 >= 3.2.40

--- a/package/yast2-partitioner.spec
+++ b/package/yast2-partitioner.spec
@@ -26,10 +26,10 @@ Source:		%{name}-%{version}.tar.bz2
 # CWM::Dialog
 Requires:	yast2 >= 3.2.40
 Requires:	yast2-ruby-bindings
-Requires:	yast2-storage-ng >= 0.1.25
+Requires:	yast2-storage-ng >= 0.1.29
 
 BuildRequires:	update-desktop-files
-BuildRequires:	yast2-storage-ng >= 0.1.25
+BuildRequires:	yast2-storage-ng >= 0.1.29
 BuildRequires:	yast2-ruby-bindings
 BuildRequires:	yast2-devtools
 BuildRequires:	yast2 >= 3.2.40

--- a/src/lib/y2partitioner/dialogs/encrypt_password.rb
+++ b/src/lib/y2partitioner/dialogs/encrypt_password.rb
@@ -8,19 +8,19 @@ module Y2Partitioner
     # Part of {Sequences::AddPartition} and {Sequences::EditBlkDevice}.
     # Formerly MiniWorkflowStepPassword
     class EncryptPassword < CWM::Dialog
-      def initialize(blk_device)
+      def initialize(options)
         textdomain "storage"
 
-        @blk_device = blk_device
+        @options = options
       end
 
       def title
-        _("Encryption password for %s") % @blk_device.plain_device.name
+        _("Encryption password for %s") % @options.name
       end
 
       def contents
         HVSquash(
-          Widgets::EncryptPassword.new(@blk_device)
+          Widgets::EncryptPassword.new(@options)
         )
       end
     end

--- a/src/lib/y2partitioner/dialogs/encrypt_password.rb
+++ b/src/lib/y2partitioner/dialogs/encrypt_password.rb
@@ -8,6 +8,7 @@ module Y2Partitioner
     # Part of {Sequences::AddPartition} and {Sequences::EditBlkDevice}.
     # Formerly MiniWorkflowStepPassword
     class EncryptPassword < CWM::Dialog
+      # @param options [Y2Partitioner::FormatMount::Options]
       def initialize(options)
         textdomain "storage"
 

--- a/src/lib/y2partitioner/dialogs/format_and_mount.rb
+++ b/src/lib/y2partitioner/dialogs/format_and_mount.rb
@@ -7,17 +7,17 @@ module Y2Partitioner
     # Part of {Sequences::AddPartition} and {Sequences::EditBlkDevice}.
     # Formerly MiniWorkflowStepFormatMount
     class FormatAndMount < CWM::Dialog
-      # @param partition [Y2Storage::Partition] FIXME: unsure which type we want
-      def initialize(partition)
-        @partition = partition
+      # @param options [Y2Partitioner::FormatMountOptions]
+      def initialize(options)
         textdomain "storage"
 
-        @format_widget = Widgets::FormatOptions.new(@partition)
-        @mount_widget  = Widgets::MountOptions.new(@partition)
+        @options = options
+        @format_widget = Widgets::FormatOptions.new(@options)
+        @mount_widget  = Widgets::MountOptions.new(@options)
       end
 
       def title
-        "Edit Partition #{@partition.name}"
+        "Edit Partition #{@options.name}"
       end
 
       def contents

--- a/src/lib/y2partitioner/dialogs/format_and_mount.rb
+++ b/src/lib/y2partitioner/dialogs/format_and_mount.rb
@@ -7,7 +7,7 @@ module Y2Partitioner
     # Part of {Sequences::AddPartition} and {Sequences::EditBlkDevice}.
     # Formerly MiniWorkflowStepFormatMount
     class FormatAndMount < CWM::Dialog
-      # @param options [Y2Partitioner::FormatMountOptions]
+      # @param options [Y2Partitioner::FormatMount::Options]
       def initialize(options)
         textdomain "storage"
 

--- a/src/lib/y2partitioner/dialogs/format_and_mount.rb
+++ b/src/lib/y2partitioner/dialogs/format_and_mount.rb
@@ -12,8 +12,8 @@ module Y2Partitioner
         textdomain "storage"
 
         @options = options
-        @format_widget = Widgets::FormatOptions.new(@options)
         @mount_widget  = Widgets::MountOptions.new(@options)
+        @format_widget = Widgets::FormatOptions.new(@options, @mount_widget)
       end
 
       def title

--- a/src/lib/y2partitioner/dialogs/format_and_mount.rb
+++ b/src/lib/y2partitioner/dialogs/format_and_mount.rb
@@ -34,14 +34,25 @@ module Y2Partitioner
         loop do
           ret = super
 
-          break if ret != :redraw
+          case ret
+          when :redraw_partition_id
+            redraw_partition_id
+          when :redraw_filesystem
+            redraw_filesystem
+          else
+            break
+          end
         end
 
         ret
       end
 
-      def skip_store_for
-        [:redraw]
+      def redraw_partition_id
+        @options.options_for_partition_id(@options.partition_id)
+      end
+
+      def redraw_filesystem
+        @options.update_filesystem_options!
       end
     end
   end

--- a/src/lib/y2partitioner/dialogs/format_and_mount.rb
+++ b/src/lib/y2partitioner/dialogs/format_and_mount.rb
@@ -12,8 +12,6 @@ module Y2Partitioner
         textdomain "storage"
 
         @options = options
-        @mount_widget  = Widgets::MountOptions.new(@options)
-        @format_widget = Widgets::FormatOptions.new(@options, @mount_widget)
       end
 
       def title
@@ -23,11 +21,23 @@ module Y2Partitioner
       def contents
         HVSquash(
           HBox(
-            @format_widget,
-            HSpacing(4),
-            @mount_widget
+            Widgets::FormatOptions.new(@options),
+            HSpacing(5),
+            Widgets::MountOptions.new(@options)
           )
         )
+      end
+
+      def run_assuming_open
+        ret = nil
+
+        loop do
+          ret = super
+
+          break if ret != :redraw
+        end
+
+        ret
       end
     end
   end

--- a/src/lib/y2partitioner/dialogs/format_and_mount.rb
+++ b/src/lib/y2partitioner/dialogs/format_and_mount.rb
@@ -28,7 +28,7 @@ module Y2Partitioner
         )
       end
 
-      def run_assuming_open
+      def cwm_show
         ret = nil
 
         loop do
@@ -38,6 +38,10 @@ module Y2Partitioner
         end
 
         ret
+      end
+
+      def skip_store_for
+        [:redraw]
       end
     end
   end

--- a/src/lib/y2partitioner/dialogs/fstab_options.rb
+++ b/src/lib/y2partitioner/dialogs/fstab_options.rb
@@ -4,6 +4,8 @@ require "y2partitioner/widgets/format_and_mount"
 
 module Y2Partitioner
   module Dialogs
+    # CWM Dialog to set specific fstab options for the blk_device being added
+    # or edited.
     class FstabOptions < CWM::Dialog
       def initialize(options)
         textdomain "storage"

--- a/src/lib/y2partitioner/dialogs/fstab_options.rb
+++ b/src/lib/y2partitioner/dialogs/fstab_options.rb
@@ -7,6 +7,7 @@ module Y2Partitioner
     # CWM Dialog to set specific fstab options for the blk_device being added
     # or edited.
     class FstabOptions < CWM::Dialog
+      # @param options [Y2Partitioner::FormatMount::Options]
       def initialize(options)
         textdomain "storage"
 

--- a/src/lib/y2partitioner/dialogs/fstab_options.rb
+++ b/src/lib/y2partitioner/dialogs/fstab_options.rb
@@ -1,0 +1,58 @@
+require "yast"
+require "cwm/dialog"
+require "y2partitioner/widgets/format_and_mount"
+
+module Y2Partitioner
+  module Dialogs
+    class FstabOptions < CWM::Dialog
+      def initialize(options)
+        textdomain "storage"
+
+        @options = options
+      end
+
+      def title
+        _("Fstab Options:")
+      end
+
+      def wizard_create_dialog(&block)
+        Yast::UI.OpenDialog(layout)
+        block.call
+      ensure
+        Yast::UI.CloseDialog()
+      end
+
+      def should_open_dialog?
+        true
+      end
+
+      def contents
+        HVSquash(Widgets::FstabOptions.new(@options))
+      end
+
+      def layout
+        VBox(
+          HSpacing(50),
+          # heading text
+          Left(Heading(Id(:title), title)),
+          VStretch(),
+          VSpacing(1),
+          HBox(
+            HStretch(),
+            HSpacing(1),
+            ReplacePoint(Id(:contents), Empty()),
+            HStretch(),
+            HSpacing(1)
+          ),
+          VSpacing(1),
+          VStretch(),
+          ButtonBox(
+            PushButton(Id(:help), Opt(:helpButton), Yast::Label.HelpButton),
+            PushButton(Id(:ok), Opt(:default), Yast::Label.OKButton),
+            PushButton(Id(:cancel), Yast::Label.CancelButton)
+          )
+        )
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/dialogs/partition_role.rb
+++ b/src/lib/y2partitioner/dialogs/partition_role.rb
@@ -13,7 +13,8 @@ module Y2Partitioner
     # Part of {Sequences::AddPartition}.
     # Formerly MiniWorkflowStepRole
     class PartitionRole < CWM::Dialog
-      # @param options [Y2Partitioner::FormatMountOptions]
+      # @param disk_name [String]
+      # @param options [Y2Partitioner::FormatMount::Options]
       def initialize(disk_name, options)
         textdomain "storage"
 
@@ -34,7 +35,7 @@ module Y2Partitioner
 
       # Choose the role of the new partition
       class RoleChoice < CWM::RadioButtons
-        # @param options [Y2Partitioner::FormatMountOptions]
+        # @param options [Y2Partitioner::FormatMount::Options]
         def initialize(options)
           textdomain "storage"
 

--- a/src/lib/y2partitioner/dialogs/partition_role.rb
+++ b/src/lib/y2partitioner/dialogs/partition_role.rb
@@ -1,0 +1,76 @@
+require "y2storage"
+require "yast"
+require "cwm/dialog"
+require "cwm/common_widgets"
+require "cwm/custom_widget"
+
+Yast.import "Popup"
+
+module Y2Partitioner
+  module Dialogs
+    # Determine the role of the new partition to be created which will allow to
+    # propose some default format and mount options for it.
+    # Part of {Sequences::AddPartition}.
+    # Formerly MiniWorkflowStepRole
+    class PartitionRole < CWM::Dialog
+      # @param options [Y2Partitioner::FormatMountOptions]
+      def initialize(disk_name, options)
+        textdomain "storage"
+
+        @disk_name = disk_name
+        @options = options
+      end
+
+      # @macro seeDialog
+      def title
+        # dialog title
+        Yast::Builtins.sformat(_("Add Partition on %1"), @disk_name)
+      end
+
+      # @macro seeDialog
+      def contents
+        HVSquash(RoleChoice.new(@options))
+      end
+
+      # Choose the role of the new partition
+      class RoleChoice < CWM::RadioButtons
+        # @param options [Y2Partitioner::FormatMountOptions]
+        def initialize(options)
+          textdomain "storage"
+
+          @options = options
+        end
+
+        # @macro seeAbstractWidget
+        def label
+          _("Role")
+        end
+
+        # @macro seeAbstractWidget
+        def help
+          _("<p>Choose the role of the device.</p>")
+        end
+
+        def items
+          [
+            [:system, _("Operating System")],
+            [:data, _("Data and ISV Applications")],
+            [:swap, _("Swap")],
+            [:efi_boot, _("EFI Boot Partition")],
+            [:raw, _("Raw Volume (unformatted)")]
+          ]
+        end
+
+        # @macro seeAbstractWidget
+        def init
+          self.value = @options.role || :data
+        end
+
+        # @macro seeAbstractWidget
+        def store
+          @options.options_for_role(value) if @options.role != value
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/dialogs/partition_size.rb
+++ b/src/lib/y2partitioner/dialogs/partition_size.rb
@@ -42,9 +42,7 @@ module Y2Partitioner
       def run
         res = super
 
-        if res == :next && @ptemplate.type.is?(:extended)
-          res = :finish
-        end
+        res = :finish if res == :next && @ptemplate.type.is?(:extended)
 
         res
       end

--- a/src/lib/y2partitioner/dialogs/partition_size.rb
+++ b/src/lib/y2partitioner/dialogs/partition_size.rb
@@ -38,6 +38,17 @@ module Y2Partitioner
         HVSquash(SizeWidget.new(@ptemplate, @regions))
       end
 
+      # return finish for extended partition, as it can set only type and its size
+      def run
+        res = super
+
+        if res == :next && @ptemplate.type.is?(:extended)
+          res = :finish
+        end
+
+        res
+      end
+
       # Like CWM::RadioButtons but each RB has a subordinate indented widget.
       # This is kind of like Pager, but all Pages being visible at once,
       # and enabled/disabled.

--- a/src/lib/y2partitioner/dialogs/partition_type.rb
+++ b/src/lib/y2partitioner/dialogs/partition_type.rb
@@ -78,7 +78,26 @@ module Y2Partitioner
 
       # @macro seeDialog
       def contents
-        HVSquash(TypeChoice.new(@ptemplate, @slots))
+        HVSquash(type_choice)
+      end
+
+      # Overwrite run. If there is only one type of partition, just select it
+      def run
+        case type_choice.items.size
+        when 0
+          raise "No partition type possible"
+        when 1
+          @ptemplate.type = Y2Storage::PartitionType.new(type_choice.items.first.first)
+          :next
+        else
+          super
+        end
+      end
+
+    private
+
+      def type_choice
+        @type_choice ||= TypeChoice.new(@ptemplate, @slots)
       end
     end
   end

--- a/src/lib/y2partitioner/format_mount/base.rb
+++ b/src/lib/y2partitioner/format_mount/base.rb
@@ -1,0 +1,74 @@
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2storage"
+require "y2partitioner/format_mount/options"
+
+module Y2Partitioner
+  module FormatMount
+    # Base class for handle common formant and mount operations
+    class Base
+      # params partition [Y2Storage::BlkDevice]
+      # @param options [Options]
+      def initialize(partition, options)
+        @partition = partition
+        @options = options
+      end
+
+      def apply_options!
+        @partition.id = @options.partition_id
+        apply_format_options!
+        apply_mount_options!
+      end
+
+      def apply_format_options!
+        return false unless @options.encrypt || @options.format
+
+        @partition.remove_descendants
+
+        if @options.encrypt
+          @partition = @partition.create_encryption("cr_#{@partition.basename}")
+          @partition.password = @options.password
+        end
+
+        @partition.create_filesystem(@options.filesystem_type) if @options.format
+
+        true
+      end
+
+      def apply_mount_options!
+        return false unless @partition.filesystem
+
+        if @options.mount
+          @partition.filesystem.mount_point = @options.mount_point
+          @partition.filesystem.mount_by = @options.mount_by
+          @partition.filesystem.label = @options.label
+          @partition.filesystem.fstab_options = @options.fstab_options
+        else
+          @partition.filesystem.mount_point = ""
+        end
+
+        true
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/format_mount/base.rb
+++ b/src/lib/y2partitioner/format_mount/base.rb
@@ -61,7 +61,7 @@ module Y2Partitioner
         if @options.mount
           @partition.filesystem.mount_point = @options.mount_point
           @partition.filesystem.mount_by = @options.mount_by
-          @partition.filesystem.label = @options.label
+          @partition.filesystem.label = @options.label if @options.label
           @partition.filesystem.fstab_options = @options.fstab_options
         else
           @partition.filesystem.mount_point = ""

--- a/src/lib/y2partitioner/format_mount/base.rb
+++ b/src/lib/y2partitioner/format_mount/base.rb
@@ -25,7 +25,7 @@ require "y2partitioner/format_mount/options"
 
 module Y2Partitioner
   module FormatMount
-    # Base class for handle common formant and mount operations
+    # Base class for handle common format and mount operations
     class Base
       # params partition [Y2Storage::BlkDevice]
       # @param options [Options]

--- a/src/lib/y2partitioner/format_mount/options.rb
+++ b/src/lib/y2partitioner/format_mount/options.rb
@@ -23,47 +23,6 @@ require "yast"
 require "y2storage"
 
 module Y2Storage
-  # FIXME: Monkey patch of Y2Storage::PartitionId it should moved to
-  # yast2-storage-ng
-  class PartitionId
-    include Yast::I18n
-    extend Yast::I18n
-
-    NOT_ALLOW_FORMAT = %i(lvm raid esp prep bios_boot unknown).freeze
-
-    TRANSLATIONS = {
-      dos12:              N_("DOS12"),
-      dos16:              N_("DOS16"),
-      dos32:              N_("DOS32"),
-      swap:               N_("Linux Swap"),
-      linux:              N_("Linux"),
-      lvm:                N_("Linux LVM"),
-      raid:               N_("Linux RAID"),
-      esp:                N_("EFI System Partition"),
-      bios_boot:          N_("BIOS Boot Partition"),
-      prep:               N_("PReP Boot Partition"),
-      ntfs:               N_("NTFS"),
-      extended:           N_("Extended"),
-      windows_basic_data: N_("Windows Data Partition"),
-      microsoft_reserved: N_("Microsoft Reserved Partition"),
-      diag:               N_("Diagnostics Partition"),
-      unknown:            N_("Unknown")
-    }.freeze
-    private_constant :TRANSLATIONS
-
-    def to_human_string
-      textdomain "storage"
-
-      string = TRANSLATIONS[to_sym] or raise "Unhandled Partition ID '#{inspect}'"
-
-      _(string)
-    end
-
-    def formattable?
-      !NOT_ALLOW_FORMAT.include?(to_sym)
-    end
-  end
-
   module Filesystems
     # FIXME: Temporal Monkey patching of fstab options per filesystem type. It
     # could/should be moved to yast2-storage-ng.

--- a/src/lib/y2partitioner/format_mount/options.rb
+++ b/src/lib/y2partitioner/format_mount/options.rb
@@ -152,11 +152,11 @@ module Y2Storage
       end
 
       def encryptable?
-        MOUNT_OPTIONS[to_sym][:supports_encryption] || false
+        MOUNT_OPTIONS[to_sym].fetch(:supports_encryption, false)
       end
 
       def formattable?
-        MOUNT_OPTIONS[to_sym][:supports_format] || false
+        MOUNT_OPTIONS[to_sym].fetch(:supports_format, false)
       end
 
       def supported_partition_id

--- a/src/lib/y2partitioner/format_mount/options.rb
+++ b/src/lib/y2partitioner/format_mount/options.rb
@@ -36,7 +36,7 @@ module Y2Storage
       dos16:              N_("DOS16"),
       dos32:              N_("DOS32"),
       swap:               N_("Linux Swap"),
-      linux:              N_("Lnux"),
+      linux:              N_("Linux"),
       lvm:                N_("Linux LVM"),
       raid:               N_("Linux RAID"),
       esp:                N_("EFI System Partition"),

--- a/src/lib/y2partitioner/format_mount_options.rb
+++ b/src/lib/y2partitioner/format_mount_options.rb
@@ -1,0 +1,54 @@
+module Y2Partitioner
+  class FormatMountOptions
+    attr_accessor :filesystem, :role, :encrypt, :type, :format, :mount_point,
+                  :mount, :name, :fstab_options, :password
+
+    def initialize(options: {}, partition: nil, role: nil)
+      options_for_partition(partition) if partition
+      options_for_partition(role) if role
+
+      options.each do |o, v|
+        self.send("#{o}=", v) if self.respond_to?("#{o}=")
+      end
+    end
+
+    def options_for_partition(partition)
+      @name = partition.name
+      @format  = false
+      @encrypt = false
+      @type = partition.type.to_sym
+      @id = partition.id
+      if partition.filesystem
+        @filesystem  = partition.filesystem_type.to_s
+        @mount_point =  partition.filesystem.mount_point
+        @fstab_options = partition.filesystem.fstab_options
+      else
+        @mount_point   = partition.respond_to?("mount_point") ? partition.mount_point : ""
+        @filesystem    = default_fs
+        @fstab_options = []
+      end
+
+      @mount = @mount_point && !@mount_point.empty?
+    end
+
+    def options_for_role(role)
+      case role
+      when :swap
+        @format      = true
+        @mount_point = "swap"
+        @filesystem  = :swap
+      when :efi_boot
+        @mount_point = "/boot/efi"
+        @format      = true
+      when :raw
+        @format      = false
+      else
+        @mount_point = ""
+      end
+    end
+
+    def default_filesystem
+      "xfs"
+    end
+  end
+end

--- a/src/lib/y2partitioner/format_mount_options.rb
+++ b/src/lib/y2partitioner/format_mount_options.rb
@@ -191,6 +191,9 @@ module Y2Partitioner
     # @return [String]
     attr_accessor :label
 
+    DEFAULT_FS = Y2Storage::Filesystems::Type::BTRFS
+    DEFAULT_HOME_FS = Y2Storage::Filesystems::Type::XFS
+
     # Constructor
     #
     # @param options [Hash]
@@ -213,7 +216,7 @@ module Y2Partitioner
       @format = false
       @encrypt = false
       @mount_by = Y2Storage::Filesystems::MountByType::UUID
-      @filesystem_type = default_fs
+      @filesystem_type = DEFAULT_FS
       @partition_id = Y2Storage::PartitionId::LINUX
       @fstab_options = []
     end
@@ -258,7 +261,7 @@ module Y2Partitioner
         @partition_id = Y2Storage::PartitionId::LVM
       else
         @mount_point = ""
-        @filesystem = (role == :system) ? default_fs : default_home_fs
+        @filesystem = (role == :system) ? DEFAULT_FS : DEFAULT_HOME_FS
         @partition_id = Y2Storage::PartitionId::LINUX
       end
     end
@@ -277,16 +280,8 @@ module Y2Partitioner
       when Y2Storage::PartitionId::ESP
         options_for_role(:efi_boot)
       else
-        @filesystem_type = partition_id.formattable? ? default_fs : nil
+        @filesystem_type = partition_id.formattable? ? DEFAULT_FS : nil
       end
-    end
-
-    def default_fs
-      Y2Storage::Filesystems::Type::BTRFS
-    end
-
-    def default_home_fs
-      Y2Storage::Filesystems::Type::XFS
     end
 
     def used_mount_points

--- a/src/lib/y2partitioner/format_mount_options.rb
+++ b/src/lib/y2partitioner/format_mount_options.rb
@@ -22,15 +22,16 @@ module Y2Partitioner
       @encrypt = false
       @type = partition.type.to_sym
       @id = partition.id
+      @mount_by = Y2Storage::Filesystems::MountByType::UUID
       if fs
         @filesystem  = partition.filesystem_type.to_s
         @mount_point = fs.mount_point
-        @mount_by =  fs.mount_by ? fs.mount_by.to_sym : :uuid
+        (@mount_by = fs.mount_by) if fs.mount_by
+        @label = fs.label
         @fstab_options = fs.fstab_options
       else
         @mount_point   = partition.respond_to?("mount_point") ? partition.mount_point : ""
         @filesystem    = default_fs
-        @mount_by = :uuid
         @fstab_options = []
       end
 

--- a/src/lib/y2partitioner/format_mount_options.rb
+++ b/src/lib/y2partitioner/format_mount_options.rb
@@ -6,25 +6,31 @@ module Y2Storage
     # FIXME: Temporal Monkey patching of fstab options per filesystem type. It
     # could/should be moved to yast2-storage-ng.
     class Type
+      COMMON_FSTAB_OPTIONS = ["async", "atime", "noatime", "user", "nouser",
+                              "auto", "noauto", "ro", "rw", "defaults"].freeze
+      EXT_FSTAB_OPTIONS = ["dev", "nodev", "usrquota", "grpquota", "acl",
+                           "noacl"].freeze
+
       MOUNT_OPTIONS = {
         btrfs:    {
-          fstab_options: ["async", "atime", "noatime", "user", "nouser", "auto",
-                          "noauto", "ro", "rw", "defaults"]
+          fstab_options:       COMMON_FSTAB_OPTIONS,
+          supports_format:     true,
+          supports_encryption: true
         },
         ext2:     {
-          fstab_options: ["async", "atime", "noatime", "user", "nouser", "auto",
-                          "noauto", "ro", "rw", "defaults", "dev", "nodev",
-                          "usrquota", "grpquota", "acl", "noacl"]
+          fstab_options:       COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS,
+          supports_format:     true,
+          supports_encryption: true
         },
         ext3:     {
-          fstab_options: ["async", "atime", "noatime", "user", "nouser", "auto",
-                          "noauto", "ro", "rw", "defaults", "dev", "nodev",
-                          "usrquota", "grpquota", "data=", "acl", "noacl"]
+          fstab_options:       COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS + ["data="],
+          supports_format:     true,
+          supports_encryption: true
         },
         ext4:     {
-          fstab_options: ["async", "atime", "noatime", "user", "nouser", "auto",
-                          "noauto", "ro", "rw", "defaults", "dev", "nodev",
-                          "usrquota", "grpquota", "data=", "acl", "noacl"]
+          fstab_options:       COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS + ["data="],
+          supports_format:     true,
+          supports_encryption: true
         },
         hfs:      {
           fstab_options: []
@@ -51,13 +57,14 @@ module Y2Storage
           fstab_options: ["priority"]
         },
         vfat:     {
-          fstab_options: ["async", "atime", "noatime", "user", "nouser", "auto",
-                          "noauto", "ro", "rw", "defaults", "dev", "nodev",
-                          "iocharset="]
+          fstab_options:       COMMON_FSTAB_OPTIONS + ["dev", "nodev", "iocharset="],
+          supports_format:     true,
+          supports_encryption: true
         },
         xfs:      {
-          fstab_options: ["async", "atime", "noatime", "user", "nouser", "auto",
-                          "noauto", "ro", "rw", "usrquota", "grpquota"]
+          fstab_options:       COMMON_FSTAB_OPTIONS + ["usrquota", "grpquota"],
+          supports_format:     true,
+          supports_encryption: true
         },
         iso9669:  {
           fstab_options: ["acl", "noacl"]
@@ -166,6 +173,12 @@ module Y2Partitioner
 
     def default_fs
       Y2Storage::Filesystems::Type::BTRFS
+    end
+
+    def used_mount_points
+      dg = DeviceGraphs.instance.current
+
+      Y2Storage::Mountable.all(dg).map(&:mount_point).compact
     end
   end
 end

--- a/src/lib/y2partitioner/format_mount_options.rb
+++ b/src/lib/y2partitioner/format_mount_options.rb
@@ -54,7 +54,9 @@ module Y2Storage
           fstab_options: []
         },
         swap:     {
-          fstab_options: ["priority"]
+          fstab_options:       ["priority"],
+          supports_format:     true,
+          supports_encryption: true
         },
         vfat:     {
           fstab_options:       COMMON_FSTAB_OPTIONS + ["dev", "nodev", "iocharset="],
@@ -67,7 +69,9 @@ module Y2Storage
           supports_encryption: true
         },
         iso9669:  {
-          fstab_options: ["acl", "noacl"]
+          fstab_options:       ["acl", "noacl"],
+          supports_format:     false,
+          supports_encryption: false
         },
         udf:      {
           fstab_options: ["acl", "noacl"]
@@ -102,6 +106,8 @@ module Y2Partitioner
     attr_accessor :encrypt
     # @return [Y2Storage::PartitionType]
     attr_accessor :partition_type
+    # @return [Y2Storage::PartitionId]
+    attr_accessor :partition_id
     # @return [String]
     attr_accessor :mount_point
     # @return [Y2Storage::Filesystems::MountBy]
@@ -142,6 +148,7 @@ module Y2Partitioner
       @encrypt = false
       @mount_by = Y2Storage::Filesystems::MountByType::UUID
       @filesystem_type = default_fs
+      @partition_id = 131
       @fstab_options = []
     end
 

--- a/src/lib/y2partitioner/format_mount_options.rb
+++ b/src/lib/y2partitioner/format_mount_options.rb
@@ -1,41 +1,150 @@
 require "yast"
 require "y2storage"
 
+module Y2Storage
+  module Filesystems
+    class Type
+      MOUNT_OPTIONS = {
+        btrfs:    {
+          fstab_options: ["async", "atime", "noatime", "user", "nouser", "auto",
+                          "noauto", "ro", "rw", "defaults"]
+
+
+        },
+        ext2:     {
+          fstab_options: ["async", "atime", "noatime", "user", "nouser", "auto",
+                          "noauto", "ro", "rw", "defaults", "dev", "nodev",
+                          "usrquota", "grpquota", "acl", "noacl"]
+
+
+        },
+        ext3:     {
+          fstab_options: ["async", "atime", "noatime", "user", "nouser", "auto",
+                          "noauto", "ro", "rw", "defaults", "dev", "nodev",
+                          "usrquota", "grpquota", "data=", "acl", "noacl"]
+
+        },
+        ext4:     {
+          fstab_options: ["async", "atime", "noatime", "user", "nouser", "auto",
+                          "noauto", "ro", "rw", "defaults", "dev", "nodev",
+                          "usrquota", "grpquota", "data=", "acl", "noacl"]
+        },
+        hfs:      {
+          fstab_options: []
+        },
+        hfsplus:  {
+          fstab_options: []
+        },
+        jfs:      {
+          fstab_options:  []
+        },
+        msdos:    {
+          fstab_options: []
+        },
+        nilfs2:   {
+          fstab_options: []
+        },
+        ntfs:     {
+          fstab_options: []
+        },
+        reiserfs: {
+          fstab_options: []
+        },
+        swap:     {
+          fstab_options: ["priority"]
+        },
+        vfat:     {
+          fstab_options: ["async", "atime", "noatime", "user", "nouser", "auto",
+                          "noauto", "ro", "rw", "defaults", "dev", "nodev",
+                          "iocharset="]
+        },
+        xfs:      {
+          fstab_options: ["async", "atime", "noatime", "user", "nouser", "auto",
+                          "noauto", "ro", "rw", "usrquota", "grpquota"]
+        },
+        iso9669:  {
+          fstab_options: ["acl", "noacl"]
+        },
+        udf:      {
+          fstab_options: ["acl", "noacl"]
+        }
+      }
+
+      def supported_fstab_options
+        MOUNT_OPTIONS[to_sym][:fstab_options] || []
+      end
+    end
+  end
+end
+
 module Y2Partitioner
   class FormatMountOptions
-    attr_accessor :filesystem, :role, :encrypt, :type, :format, :mount_point,
-      :mount_by, :mount, :name, :fstab_options, :password, :label
+    # @return [Y2Storage::Filesystem::Type]
+    attr_accessor :filesystem_type
+    # @return [:system, :data, :swap, :boot_efi]
+    attr_accessor :role
+    # @return [Boolean]
+    attr_accessor :encrypt
+    # @return [Y2Storage::PartitionType]
+    attr_accessor :partition_type
+    # @return [String]
+    attr_accessor :mount_point
+    # @return [Y2Storage::Filesystems::MountBy]
+    attr_accessor :mount_by
+    # @return [Boolean]
+    attr_accessor :format
+    # @return [Boolean]
+    attr_accessor :mount
+    # @return [String]
+    attr_accessor :name
+    # @return [Array<String>]
+    attr_accessor :fstab_options
+    # @return [String]
+    attr_accessor :password
+    # @return [String]
+    attr_accessor :label
 
+    # Constructor
+    #
+    # @param options [Hash]
+    # @param partition [Y2Storage::BlkDevice]
+    # @param role [Symbol]
     def initialize(options: {}, partition: nil, role: nil)
+      set_defaults!
+
+      options_for_role(role) if role
       options_for_partition(partition) if partition
-      options_for_partition(role) if role
+
+      @mount = @mount_point && !@mount_point.empty?
 
       options.each do |o, v|
         send("#{o}=", v) if respond_to?("#{o}=")
       end
     end
 
-    def options_for_partition(partition)
-      fs = partition.filesystem
-      @name = partition.name
-      @format  = false
-      @encrypt = false
-      @type = partition.type.to_sym
-      @id = partition.id
+    def set_defaults!
+      @format   = false
+      @encrypt  = false
       @mount_by = Y2Storage::Filesystems::MountByType::UUID
+      @filesystem_type    = default_fs
+      @fstab_options = []
+    end
+
+    def options_for_partition(partition, defaults = false)
+      @name = partition.name
+      @type = partition.type
+      @id = partition.id
+      @mount_point   = partition.respond_to?("mount_point") ? partition.mount_point : ""
+
+      options_for_filesystem(partition.filesystem) if partition.filesystem
+      fs = partition.filesystem
       if fs
-        @filesystem  = partition.filesystem_type.to_s
+        @filesystem_type  = partition.filesystem_type
         @mount_point = fs.mount_point
-        (@mount_by = fs.mount_by) if fs.mount_by
+        @mount_by = fs.mount_by if fs.mount_by
         @label = fs.label
         @fstab_options = fs.fstab_options
-      else
-        @mount_point   = partition.respond_to?("mount_point") ? partition.mount_point : ""
-        @filesystem    = default_fs
-        @fstab_options = []
       end
-
-      @mount = @mount_point && !@mount_point.empty?
     end
 
     def options_for_role(role)
@@ -43,7 +152,7 @@ module Y2Partitioner
       when :swap
         @format      = true
         @mount_point = "swap"
-        @filesystem  = :swap
+        @filesystem_type  = Y2Storage::Filesystems::Type::SWAP
       when :efi_boot
         @mount_point = "/boot/efi"
         @format      = true
@@ -51,12 +160,25 @@ module Y2Partitioner
         @format      = false
       else
         @mount_point = ""
-        @filesystem = default_filesystem
+        @filesystem = default_fs
       end
     end
 
-    def default_filesystem
-      "xfs"
+    def options_for_filesystem(filesystem)
+      case filesystem.type
+      when Y2Storage::Filesystems::Type::SWAP
+        @mount_point = "swap"
+      when Y2Storage::Filesystems::Type::EXT2
+      when Y2Storage::Filesystems::Type::EXT3
+      when Y2Storage::Filesystems::Type::EXT4
+      when Y2Storage::Filesystems::Type::XFS
+      when Y2Storage::Filesystems::Type::BTRFS
+      else
+      end
+    end
+
+    def default_fs
+      Y2Storage::Filesystems::Type::BTRFS
     end
   end
 end

--- a/src/lib/y2partitioner/format_mount_options.rb
+++ b/src/lib/y2partitioner/format_mount_options.rb
@@ -1,7 +1,70 @@
+# encoding: utf-8
+
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 require "yast"
 require "y2storage"
 
 module Y2Storage
+  # FIXME: Monkey patch of Y2Storage::PartitionId it should moved to
+  # yast2-storage-ng
+  class PartitionId
+    include Yast::I18n
+    extend Yast::I18n
+
+    TRANSLATIONS = {
+      dos12:              N_("DOS12"),
+      dos16:              N_("DOS16"),
+      dos32:              N_("DOS32"),
+      swap:               N_("Linux Swap"),
+      linux:              N_("Lnux"),
+      lvm:                N_("Linux LVM"),
+      raid:               N_("Linux RAID"),
+      esp:                N_("EFI System Partition"),
+      bios_boot:          N_("BIOS Boot Partition"),
+      prep:               N_("PReP Boot Partition"),
+      ntfs:               N_("NTFS"),
+      extended:           N_("Extended"),
+      windows_basic_data: N_("Windows Data Partition"),
+      microsoft_reserved: N_("Microsoft Reserved Partition"),
+      diag:               N_("Diagnostics Partition"),
+      unknown:            N_("Unknown")
+    }.freeze
+    private_constant :TRANSLATIONS
+
+    def to_human_string
+      textdomain "storage"
+
+      string = TRANSLATIONS[to_sym] or raise "Unhandled Partition ID '#{inspect}'"
+
+      _(string)
+    end
+
+    def formattable?
+      !%i[lvm raid esp prep bios_boot unknown].include?(to_sym)
+    end
+
+    def encryptable?
+    end
+  end
+
   module Filesystems
     # FIXME: Temporal Monkey patching of fstab options per filesystem type. It
     # could/should be moved to yast2-storage-ng.
@@ -15,22 +78,26 @@ module Y2Storage
         btrfs:    {
           fstab_options:       COMMON_FSTAB_OPTIONS,
           supports_format:     true,
-          supports_encryption: true
+          supports_encryption: true,
+          partition_id:        Y2Storage::PartitionId::LINUX
         },
         ext2:     {
           fstab_options:       COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS,
           supports_format:     true,
-          supports_encryption: true
+          supports_encryption: true,
+          partition_id:        Y2Storage::PartitionId::LINUX
         },
         ext3:     {
           fstab_options:       COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS + ["data="],
           supports_format:     true,
-          supports_encryption: true
+          supports_encryption: true,
+          partition_id:        Y2Storage::PartitionId::LINUX
         },
         ext4:     {
           fstab_options:       COMMON_FSTAB_OPTIONS + EXT_FSTAB_OPTIONS + ["data="],
           supports_format:     true,
-          supports_encryption: true
+          supports_encryption: true,
+          partition_id:        Y2Storage::PartitionId::LINUX
         },
         hfs:      {
           fstab_options: []
@@ -56,7 +123,8 @@ module Y2Storage
         swap:     {
           fstab_options:       ["priority"],
           supports_format:     true,
-          supports_encryption: true
+          supports_encryption: true,
+          partition_id:        Y2Storage::PartitionId::SWAP
         },
         vfat:     {
           fstab_options:       COMMON_FSTAB_OPTIONS + ["dev", "nodev", "iocharset="],
@@ -66,7 +134,8 @@ module Y2Storage
         xfs:      {
           fstab_options:       COMMON_FSTAB_OPTIONS + ["usrquota", "grpquota"],
           supports_format:     true,
-          supports_encryption: true
+          supports_encryption: true,
+          partition_id:        Y2Storage::PartitionId::LINUX
         },
         iso9669:  {
           fstab_options:       ["acl", "noacl"],
@@ -148,7 +217,7 @@ module Y2Partitioner
       @encrypt = false
       @mount_by = Y2Storage::Filesystems::MountByType::UUID
       @filesystem_type = default_fs
-      @partition_id = 131
+      @partition_id = Y2Storage::PartitionId::LINUX
       @fstab_options = []
     end
 
@@ -159,12 +228,36 @@ module Y2Partitioner
       @mount_point = partition.respond_to?("mount_point") ? partition.mount_point : ""
 
       fs = partition.filesystem
-      if fs
-        @filesystem_type = partition.filesystem_type
-        @mount_point = fs.mount_point
-        @mount_by = fs.mount_by if fs.mount_by
-        @label = fs.label
-        @fstab_options = fs.fstab_options
+
+      return unless fs
+
+      @filesystem_type = partition.filesystem_type
+      @mount_point = fs.mount_point
+      @mount_by = fs.mount_by if fs.mount_by
+      @label = fs.label
+      @fstab_options = fs.fstab_options
+    end
+
+    def options_for_windows_partition(partition_id)
+      @filesystem_type = Y2Storage::Filesystems::Type::VFAT
+    end
+
+    def options_for_partition_id(partition_id)
+      return options_for_windows_partition(partiton_id) if partiton_id.is?(:windows_system)
+
+      case partition_id
+      when Y2Storage::PartitionId::SWAP
+        options_for_role(:swap)
+      when Y2Storage::PartitionId::ESP
+        options_for_role(:efi_boot)
+      else
+
+        if partition_id.formattable?
+          @filesystem_type = default_fs
+
+        else
+          @filesystem_type = partition_id.formattable? ? Y2Storage::Filesystems::Type::EXT4 : nil
+        end
       end
     end
 
@@ -172,14 +265,13 @@ module Y2Partitioner
     def options_for_role(role)
       case role
       when :swap
-        @format = true
         @mount_point = "swap"
         @filesystem_type = Y2Storage::Filesystems::Type::SWAP
+        @partition_id = Y2Storage::PartitionId::SWAP
       when :efi_boot
         @mount_point = "/boot/efi"
-        @format = true
+        @partition_id = Y2Storage::PartitionId::ESP
       when :raw
-        @format = false
       else
         @mount_point = ""
         @filesystem = default_fs

--- a/src/lib/y2partitioner/format_mount_options.rb
+++ b/src/lib/y2partitioner/format_mount_options.rb
@@ -264,6 +264,8 @@ module Y2Partitioner
         @filesystem = (role == :system) ? DEFAULT_FS : DEFAULT_HOME_FS
         @partition_id = Y2Storage::PartitionId::LINUX
       end
+
+      @role = role
     end
 
     def options_for_windows_partition(_partition_id)

--- a/src/lib/y2partitioner/format_mount_options.rb
+++ b/src/lib/y2partitioner/format_mount_options.rb
@@ -243,7 +243,7 @@ module Y2Partitioner
     end
 
     def options_for_partition_id(partition_id)
-      return options_for_windows_partition(partiton_id) if partiton_id.is?(:windows_system)
+      return options_for_windows_partition(partition_id) if partition_id.is?(:windows_system)
 
       case partition_id
       when Y2Storage::PartitionId::SWAP

--- a/src/lib/y2partitioner/format_mount_options.rb
+++ b/src/lib/y2partitioner/format_mount_options.rb
@@ -1,30 +1,36 @@
+require "yast"
+require "y2storage"
+
 module Y2Partitioner
   class FormatMountOptions
     attr_accessor :filesystem, :role, :encrypt, :type, :format, :mount_point,
-                  :mount, :name, :fstab_options, :password
+      :mount_by, :mount, :name, :fstab_options, :password, :label
 
     def initialize(options: {}, partition: nil, role: nil)
       options_for_partition(partition) if partition
       options_for_partition(role) if role
 
       options.each do |o, v|
-        self.send("#{o}=", v) if self.respond_to?("#{o}=")
+        send("#{o}=", v) if respond_to?("#{o}=")
       end
     end
 
     def options_for_partition(partition)
+      fs = partition.filesystem
       @name = partition.name
       @format  = false
       @encrypt = false
       @type = partition.type.to_sym
       @id = partition.id
-      if partition.filesystem
+      if fs
         @filesystem  = partition.filesystem_type.to_s
-        @mount_point =  partition.filesystem.mount_point
-        @fstab_options = partition.filesystem.fstab_options
+        @mount_point = fs.mount_point
+        @mount_by =  fs.mount_by ? fs.mount_by.to_sym : :uuid
+        @fstab_options = fs.fstab_options
       else
         @mount_point   = partition.respond_to?("mount_point") ? partition.mount_point : ""
         @filesystem    = default_fs
+        @mount_by = :uuid
         @fstab_options = []
       end
 
@@ -44,6 +50,7 @@ module Y2Partitioner
         @format      = false
       else
         @mount_point = ""
+        @filesystem = default_filesystem
       end
     end
 

--- a/src/lib/y2partitioner/format_mount_options.rb
+++ b/src/lib/y2partitioner/format_mount_options.rb
@@ -77,6 +77,14 @@ module Y2Storage
       def supported_fstab_options
         MOUNT_OPTIONS[to_sym][:fstab_options] || []
       end
+
+      def encryptable?
+        MOUNT_OPTIONS[to_sym][:supports_encryption] || false
+      end
+
+      def formattable?
+        MOUNT_OPTIONS[to_sym][:supports_format] || false
+      end
     end
   end
 end

--- a/src/lib/y2partitioner/sequences/add_partition.rb
+++ b/src/lib/y2partitioner/sequences/add_partition.rb
@@ -48,7 +48,7 @@ module Y2Partitioner
           "size"           => { next: "role", finish: :finish },
           "role"           => { next: "format_options" },
           "format_options" => { next: "password" },
-          "password"       => { finish: :format_mount },
+          "password"       => { next: "format_mount" },
           "format_mount"   => { finish: :finish }
         }
 
@@ -107,6 +107,8 @@ module Y2Partitioner
         ptable = disk.partition_table
         name = next_free_primary_partition_name(@disk_name, ptable)
         partition = ptable.create_partition(name, @ptemplate.region, @ptemplate.type)
+
+        partition.id = @options.partition_id
 
         if @options.encrypt
           partition = partition.create_encryption(dm_name_for(@partition))

--- a/src/lib/y2partitioner/sequences/add_partition.rb
+++ b/src/lib/y2partitioner/sequences/add_partition.rb
@@ -33,7 +33,7 @@ module Y2Partitioner
         textdomain "storage"
         @disk_name = disk_name
         @ptemplate = PartitionTemplate.new
-        @options = FormatMountOptions.new
+        @options = FormatMount::Options.new
       end
 
       def disk
@@ -108,22 +108,7 @@ module Y2Partitioner
         name = next_free_primary_partition_name(@disk_name, ptable)
         partition = ptable.create_partition(name, @ptemplate.region, @ptemplate.type)
 
-        partition.id = @options.partition_id
-
-        if @options.encrypt
-          partition = partition.create_encryption(dm_name_for(@partition))
-        end
-
-        partition.create_filesystem(@options.filesystem_type) if @options.format
-
-        if @options.mount
-          partition.filesystem.mount_point = @options.mount_point
-          partition.filesystem.mount_by = @options.mount_by
-          partition.filesystem.label = @options.label
-          partition.filesystem.fstab_options = @options.fstab_options
-        else
-          partition.filesystem.mount_point = ""
-        end
+        FormatMount::Base.new(partition, @options).apply_options!
 
         :finish
       end

--- a/src/lib/y2partitioner/sequences/add_partition.rb
+++ b/src/lib/y2partitioner/sequences/add_partition.rb
@@ -50,7 +50,7 @@ module Y2Partitioner
           "role"           => { next: "format_options" },
           "format_options" => { next: "password" },
           "password"       => { next: "commit" },
-          "commit"         => { finish: :finish },
+          "commit"         => { finish: :finish }
         }
 
         sym = nil
@@ -108,7 +108,9 @@ module Y2Partitioner
         name = next_free_partition_name(@disk_name, ptable, @ptemplate.type)
         partition = ptable.create_partition(name, @ptemplate.region, @ptemplate.type)
 
-        FormatMount::Base.new(partition, @options).apply_options! unless @ptemplate.type.is?(:extended)
+        if !@ptemplate.type.is?(:extended)
+          FormatMount::Base.new(partition, @options).apply_options!
+        end
 
         :finish
       end

--- a/src/lib/y2partitioner/sequences/add_partition.rb
+++ b/src/lib/y2partitioner/sequences/add_partition.rb
@@ -1,6 +1,7 @@
 require "yast"
 require "ui/sequence"
 require "y2partitioner/device_graphs"
+require "y2partitioner/dialogs/partition_role"
 require "y2partitioner/dialogs/partition_size"
 require "y2partitioner/dialogs/partition_type"
 require "y2partitioner/dialogs/encrypt_password"
@@ -97,8 +98,7 @@ module Y2Partitioner
       end
 
       def role
-        log.info "TODO: Partition ROLE dialog"
-        :next
+        Dialogs::PartitionRole.run(disk.name, @options)
       end
 
       skip_stack :role

--- a/src/lib/y2partitioner/sequences/edit_blk_device.rb
+++ b/src/lib/y2partitioner/sequences/edit_blk_device.rb
@@ -21,7 +21,7 @@ module Y2Partitioner
 
       def run
         sequence_hash = {
-          "ws_start"     => "format_options",
+          "ws_start"       => "format_options",
           # FIXME: If encryption password is set in a different step then it
           # allows to go back and reset all the options to not modify the
           # partition at all but since the moment :next is preset the partition

--- a/src/lib/y2partitioner/sequences/edit_blk_device.rb
+++ b/src/lib/y2partitioner/sequences/edit_blk_device.rb
@@ -74,7 +74,7 @@ module Y2Partitioner
           @partition = @partition.create_encryption(dm_name_for(@partition))
         end
 
-        @partition.create_filesystem(@options.filesystem) if @options.format
+        @partition.create_filesystem(@options.filesystem_type) if @options.format
 
         if @options.mount
           @partition.filesystem.mount_point = @options.mount_point

--- a/src/lib/y2partitioner/sequences/edit_blk_device.rb
+++ b/src/lib/y2partitioner/sequences/edit_blk_device.rb
@@ -24,8 +24,8 @@ module Y2Partitioner
         sequence_hash = {
           "ws_start"       => "format_options",
           "format_options" => { next: "password" },
-          "password"       => { next: "format_mount" },
-          "format_mount"   => { finish: :finish }
+          "password"       => { next: "commit" },
+          "commit"         => { finish: :finish }
         }
 
         sym = nil
@@ -60,7 +60,7 @@ module Y2Partitioner
         @encrypt_dialog.run
       end
 
-      def format_mount
+      def commit
         FormatMount::Base.new(@partition, @options).apply_options!
 
         :finish

--- a/src/lib/y2partitioner/sequences/edit_blk_device.rb
+++ b/src/lib/y2partitioner/sequences/edit_blk_device.rb
@@ -23,13 +23,6 @@ module Y2Partitioner
       def run
         sequence_hash = {
           "ws_start"       => "format_options",
-          # FIXME: If encryption password is set in a different step then it
-          # allows to go back and reset all the options to not modify the
-          # partition at all but since the moment :next is preset the partition
-          # will be altered. We could work with a FormatOptions object that
-          # could be a Struct or Hash and just set all the options there and
-          # format in a extra step at the end of the sequence or we could make
-          # the password step part of format_and_mount.
           "format_options" => { next: "password" },
           "password"       => { next: "format_mount" },
           "format_mount"   => { finish: :finish }
@@ -68,6 +61,7 @@ module Y2Partitioner
       end
 
       def format_mount
+        @partition.id = @options.partition_id
         @partition.remove_descendants if @options.encrypt || @options.format
 
         if @options.encrypt

--- a/src/lib/y2partitioner/sequences/edit_blk_device.rb
+++ b/src/lib/y2partitioner/sequences/edit_blk_device.rb
@@ -6,6 +6,7 @@ require "y2partitioner/dialogs/partition_type"
 require "y2partitioner/dialogs/encrypt_password"
 require "y2partitioner/format_mount/base"
 
+Yast.import "Popup"
 Yast.import "Wizard"
 
 module Y2Partitioner
@@ -22,7 +23,8 @@ module Y2Partitioner
 
       def run
         sequence_hash = {
-          "ws_start"       => "format_options",
+          "ws_start"       => "preconditions",
+          "preconditions"  => { next: "format_options" },
           "format_options" => { next: "password" },
           "password"       => { next: "commit" },
           "commit"         => { finish: :finish }
@@ -46,6 +48,16 @@ module Y2Partitioner
       ensure
         Yast::Wizard.CloseDialog
       end
+
+      def preconditions
+        if @partition.type.is?(:extended)
+          Yast::Popup.Error(_("An extended partition cannot be edited"))
+          :back
+        else
+          :next
+        end
+      end
+      skip_stack :preconditions
 
       def format_options
         @format_dialog ||= Dialogs::FormatAndMount.new(@options)

--- a/src/lib/y2partitioner/sequences/edit_blk_device.rb
+++ b/src/lib/y2partitioner/sequences/edit_blk_device.rb
@@ -75,7 +75,14 @@ module Y2Partitioner
 
         @partition.create_filesystem(@options.filesystem) if @options.format
 
-        (@partition.filesystem.mount_point = @options.mount_point) if @options.mount
+        if @options.mount
+          @partition.filesystem.mount_point = @options.mount_point
+          @partition.filesystem.mount_by = @options.mount_by
+          @partition.filesystem.label = @options.label
+          @partition.filesystem.fstab_options = @options.fstab_options
+        else
+          @partition.filesystem.mount_point = ""
+        end
 
         :finish
       end

--- a/src/lib/y2partitioner/sequences/edit_blk_device.rb
+++ b/src/lib/y2partitioner/sequences/edit_blk_device.rb
@@ -3,6 +3,7 @@ require "ui/sequence"
 require "y2partitioner/device_graphs"
 require "y2partitioner/dialogs/partition_size"
 require "y2partitioner/dialogs/partition_type"
+require "y2partitioner/dialogs/encrypt_password"
 require "y2partitioner/format_mount_options"
 
 Yast.import "Wizard"

--- a/src/lib/y2partitioner/widgets/encrypt_password.rb
+++ b/src/lib/y2partitioner/widgets/encrypt_password.rb
@@ -6,10 +6,10 @@ module Y2Partitioner
   module Widgets
     # Encrypted {Y2Storage::BlkDevice} password
     class EncryptPassword < CWM::CustomWidget
-      def initialize(blk_device)
+      def initialize(options)
         textdomain "storage"
 
-        @blk_device = blk_device
+        @options = options
       end
 
       def helptext
@@ -41,7 +41,7 @@ module Y2Partitioner
       end
 
       def store
-        @blk_device.encryption.password = pw1 if @blk_device.encryption
+        @options.password = pw1
       end
 
       def contents

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -9,14 +9,13 @@ module Y2Partitioner
   module Widgets
     # Format options for {Y2Storage::BlkDevice}
     class FormatOptions < CWM::CustomWidget
-      def initialize(options, mount_widget)
+      def initialize(options)
         textdomain "storage"
 
         @options = options
 
         @encrypt_widget    = EncryptBlkDevice.new(@options.encrypt)
         @filesystem_widget = BlkDeviceFilesystem.new(@options)
-        @mount_widget = mount_widget
 
         self.handle_all_events = true
       end
@@ -37,12 +36,7 @@ module Y2Partitioner
         when :no_format_device
           select_no_format
         when @filesystem_widget.widget_id
-          # FIXME: When the filesystem change it should reload all the
-          # widgets, a redraw will lost the focus.
-          store
-          @filesystem_widget.store
-
-          @mount_widget.reload
+          return :redraw
         end
 
         nil

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -174,7 +174,7 @@ module Y2Partitioner
 
       def contents
         Frame(
-          _("Mount Options"),
+          _("Mounting Options"),
           MarginBox(
             1.45,
             0.5,

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -56,6 +56,25 @@ module Y2Partitioner
         nil
       end
 
+      def help
+        text = "<p>First, choose whether the partition should be\n" \
+                "formatted and the desired file system type.</p>"
+
+        text <<
+          _(
+            "<p>If you want to encrypt all data on the\n" \
+            "volume, select <b>Encrypt Device</b>. Changing the encryption on an existing\n" \
+            "volume will delete all data on it.</p>\n"
+          )
+        text <<
+          _(
+            "<p>Then, choose whether the partition should\n" \
+            "be mounted and enter the mount point (/, /boot, /home, /var, etc.).</p>"
+          )
+
+        text
+      end
+
       def contents
         Frame(
           _("Format Options"),
@@ -243,7 +262,6 @@ module Y2Partitioner
       end
 
       def store
-
         @options.filesystem_type = value ? Y2Storage::Filesystems::Type.find(value) : value
       end
     end

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -1,6 +1,6 @@
 require "yast"
-require "cwm"
 require "y2storage"
+require "cwm/custom_widget"
 require "y2partitioner/format_mount_options"
 require "y2partitioner/dialogs/fstab_options"
 require "y2partitioner/widgets/fstab_options"
@@ -37,7 +37,10 @@ module Y2Partitioner
         when :no_format_device
           select_no_format
         when @filesystem_widget.widget_id
+          # FIXME: When the filesystem change it should reload all the
+          # widgets, a redraw will lost the focus.
           store
+          @filesystem_widget.store
 
           @mount_widget.reload
         end
@@ -199,12 +202,6 @@ module Y2Partitioner
         self.value = @options.filesystem_type.to_sym
       end
 
-      def handle
-        store
-
-        nil
-      end
-
       def label
         _("Filesystem")
       end
@@ -224,6 +221,8 @@ module Y2Partitioner
       end
     end
 
+    # Push Button that launches a dialog to set speficic options for the
+    # selected filesystem
     class FormatOptionsButton < CWM::PushButton
       def initialize(options)
         @options = options
@@ -238,12 +237,12 @@ module Y2Partitioner
       end
 
       def handle
-        #Dialogs::FormatOptions.new(@options).run
+        # Dialogs::FormatOptions.new(@options).run
 
         nil
       end
-
     end
+
     # MountPoint selector
     class MountPoint < CWM::ComboBox
       def initialize(options)
@@ -290,7 +289,7 @@ module Y2Partitioner
       end
     end
 
-    # Format option
+    # Inode Size format option
     class InodeSize < CWM::ComboBox
       SIZES = ["auto", "512", "1024", "2048", "4096"].freeze
 
@@ -310,7 +309,7 @@ module Y2Partitioner
       end
     end
 
-    # Format option
+    # Block Size format option
     class BlockSize < CWM::ComboBox
       SIZES = ["auto", "512", "1024", "2048", "4096"].freeze
 

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -1,7 +1,7 @@
 require "yast"
 require "y2storage"
 require "cwm/custom_widget"
-require "y2partitioner/format_mount_options"
+require "y2partitioner/format_mount/options"
 require "y2partitioner/dialogs/fstab_options"
 require "y2partitioner/widgets/fstab_options"
 

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -269,6 +269,7 @@ module Y2Partitioner
       end
     end
 
+    # Format option
     class InodeSize < CWM::ComboBox
       SIZES = ["auto", "512", "1024", "2048", "4096"].freeze
 
@@ -288,6 +289,7 @@ module Y2Partitioner
       end
     end
 
+    # Format option
     class BlockSize < CWM::ComboBox
       SIZES = ["auto", "512", "1024", "2048", "4096"].freeze
 
@@ -311,6 +313,7 @@ module Y2Partitioner
       end
     end
 
+    # Format option (VFAT)
     class IOCharset < CWM::ComboBox
       def initialize(options)
         @options = options

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -60,16 +60,16 @@ module Y2Partitioner
       end
 
       def help
-        text = "<p>First, choose whether the partition should be\n" \
-                "formatted and the desired file system type.</p>"
+        text = _("<p>First, choose whether the partition should be\n" \
+                "formatted and the desired file system type.</p>")
 
-        text <<
+        text +=
           _(
             "<p>If you want to encrypt all data on the\n" \
             "volume, select <b>Encrypt Device</b>. Changing the encryption on an existing\n" \
             "volume will delete all data on it.</p>\n"
           )
-        text <<
+        text +=
           _(
             "<p>Then, choose whether the partition should\n" \
             "be mounted and enter the mount point (/, /boot, /home, /var, etc.).</p>"

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -80,7 +80,7 @@ module Y2Partitioner
 
       def contents
         Frame(
-          _("Format Options"),
+          _("Formatting Options"),
           MarginBox(
             1.45,
             0.5,

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -43,6 +43,8 @@ module Y2Partitioner
         when :no_format_device
           select_no_format
         when @filesystem_widget.widget_id
+          @filesystem_widget.store
+          store
           return :redraw
         when @partition_id.widget_id
           @partition_id.store

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -5,6 +5,8 @@ require "y2partitioner/format_mount/options"
 require "y2partitioner/dialogs/fstab_options"
 require "y2partitioner/widgets/fstab_options"
 
+Yast.import "Popup"
+
 module Y2Partitioner
   module Widgets
     # Format options for {Y2Storage::BlkDevice}
@@ -291,7 +293,7 @@ module Y2Partitioner
       end
 
       def handle
-        # Dialogs::FormatOptions.new(@options).run
+        Yast::Popup.Error("Not yet implemented") # Dialogs::FormatOptions.new(@options).run
 
         nil
       end

--- a/src/lib/y2partitioner/widgets/format_and_mount.rb
+++ b/src/lib/y2partitioner/widgets/format_and_mount.rb
@@ -237,7 +237,7 @@ module Y2Partitioner
       end
 
       def opt
-        %i[hstretch notify]
+        %i(hstretch notify)
       end
 
       def init
@@ -258,7 +258,7 @@ module Y2Partitioner
       end
 
       def supported?(fs)
-        %i[swap btrfs ext2 ext3 ext4 vfat xfs reiserfs].include?(fs.to_sym)
+        %i(swap btrfs ext2 ext3 ext4 vfat xfs reiserfs).include?(fs.to_sym)
       end
 
       def store
@@ -274,7 +274,7 @@ module Y2Partitioner
       end
 
       def opt
-        %i[hstretch notify]
+        %i(hstretch notify)
       end
 
       def label
@@ -303,7 +303,7 @@ module Y2Partitioner
       end
 
       def opt
-        %i[editable hstretch notify]
+        %i(editable hstretch notify)
       end
 
       def store
@@ -387,7 +387,7 @@ module Y2Partitioner
       end
 
       def opt
-        %i[hstretch notify]
+        %i(hstretch notify)
       end
 
       # FIXME: initialize with the correct value

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -4,11 +4,18 @@ require "y2storage"
 
 module Y2Partitioner
   module Widgets
+    # Fstab mixin
     module FstabCommon
+      def initialize(options)
+        textdomain "storage"
+
+        @options = options
+      end
+
       def supported_by_filesystem?
         return false if !@options.filesystem_type
 
-        if self.respond_to?("supported_filesystems")
+        if respond_to?("supported_filesystems")
           supported_filesystems.include?(@options.filesystem_type.to_sym)
         else
           self.class.const_get("VALUES").all? do |v|
@@ -16,13 +23,33 @@ module Y2Partitioner
           end
         end
       end
+
+      def draw_widget?(widget)
+        return true if widget.supported_by_filesystem?
+
+        false
+      end
+
+      def draw(widget)
+        return Empty() unless draw_widget?(widget)
+
+        Left(widget)
+      end
+
+      def draw_with_vspace(widget)
+        return [Empty()] unless draw_widget?(widget)
+
+        [Left(widget), VSpacing(1)]
+      end
+
+      def delete_from_fstab!(option)
+        @options.fstab_options.delete_if { |o| o =~ option }
+      end
     end
 
     # Push button that launch a dialog for set the fstab options
     class FstabOptionsButton < CWM::PushButton
-      def initialize(options)
-        @options = options
-      end
+      include FstabCommon
 
       def label
         _("Fstab options...")
@@ -35,13 +62,12 @@ module Y2Partitioner
       end
     end
 
+    # FIXME: The help handle does not work without wizard
     # Main widget for set all the available options for a particular filesystem
     class FstabOptions < CWM::CustomWidget
       include FstabCommon
 
       def initialize(options)
-        textdomain "storage"
-
         @options = options
 
         self.handle_all_events = true
@@ -51,10 +77,13 @@ module Y2Partitioner
         disable if !supported_by_filesystem?
       end
 
-      def help
-      end
+      def handle(event)
+        case event["ID"]
+        when :help
+          Yast::Wizard.ShowHelp()
+        end
 
-      def store
+        nil
       end
 
       def contents
@@ -73,26 +102,11 @@ module Y2Partitioner
       def supported_filesystems
         [:btrfs, :ext2, :ext3, :ext4, :reiserfs]
       end
-    private
-      def draw_widget?(widget)
-        return true if widget.supported_by_filesystem?
-
-        false
-      end
-
-      def draw_with_vspace(widget)
-        return [Empty()] unless draw_widget?(widget)
-
-        [Left(widget), VSpacing(1)]
-      end
-
-
     end
 
+    # Input field to set the partition Label
     class VolumeLabel < CWM::InputField
-      def initialize(options)
-        @options = options
-      end
+      include FstabCommon
 
       def label
         _("Volume &Label")
@@ -107,12 +121,10 @@ module Y2Partitioner
       end
     end
 
+    # Group of radio buttons to select the type of identifier to be used for
+    # mouth the specific device (UUID, Label, Path...)
     class MountBy < CWM::CustomWidget
-      def initialize(options)
-        textdomain "storage"
-
-        @options = options
-      end
+      include FstabCommon
 
       def label
         _("Mount in /etc/fstab by")
@@ -160,12 +172,9 @@ module Y2Partitioner
       end
     end
 
+    # A group of options that are general for many filesystem types.
     class GeneralOptions < CWM::CustomWidget
-      def initialize(options)
-        textdomain "storage"
-
-        @options = options
-      end
+      include FstabCommon
 
       def contents
         return Empty() unless widgets.any? { |w| draw_widget?(w) }
@@ -182,35 +191,20 @@ module Y2Partitioner
           Quota.new(@options)
         ]
       end
-
-    private
-      def draw_widget?(widget)
-        return true if widget.supported_by_filesystem?
-
-        false
-      end
-
-      def draw(widget)
-        return Empty() unless draw_widget?(widget)
-
-        Left(widget)
-      end
     end
 
+    # CheckBox to disable the automount option when starting up
     class Noauto < CWM::CheckBox
       include FstabCommon
-      VALUES = ["noauto", "auto"].freeze
 
-      def initialize(options)
-        @options = options
-      end
+      VALUES = ["noauto", "auto"].freeze
 
       def init
         self.value = @options.fstab_options.include?("noauto")
       end
 
       def store
-        @options.fstab_options.delete_if { |o| VALUES.include?(o) }
+        delete_from_fstab!(Regexp.union(VALUES))
 
         @options.fstab_options << "noauto" if value
       end
@@ -223,20 +217,17 @@ module Y2Partitioner
       end
     end
 
+    # CheckBox to enable the read only option ("ro")
     class ReadOnly < CWM::CheckBox
       include FstabCommon
       VALUES = ["rw", "ro"].freeze
-
-      def initialize(options)
-        @options = options
-      end
 
       def init
         self.value = @options.fstab_options.include?("ro")
       end
 
       def store
-        @options.fstab_options.delete_if { |o| VALUES.include?(o) }
+        delete_from_fstab!(Regexp.union(VALUES))
 
         @options.fstab_options << "ro" if value
       end
@@ -252,20 +243,17 @@ module Y2Partitioner
       end
     end
 
+    # CheckBox to enable the noatime option
     class Noatime < CWM::CheckBox
       include FstabCommon
       VALUES = ["noatime", "atime"].freeze
-
-      def initialize(options)
-        @options = options
-      end
 
       def init
         self.value = @options.fstab_options.include?("noatime")
       end
 
       def store
-        @options.fstab_options.delete_if { |o| VALUES.include?(o) }
+        delete_from_fstab!(Regexp.union(VALUES))
 
         @options.fstab_options << "noatime" if value
       end
@@ -280,20 +268,18 @@ module Y2Partitioner
       end
     end
 
+    # CheckBox to enable the user option which means allow to mount the
+    # filesystem by an ordinary user
     class MountUser < CWM::CheckBox
       include FstabCommon
       VALUES = ["user", "nouser"].freeze
-
-      def initialize(options)
-        @options = options
-      end
 
       def init
         self.value = @options.fstab_options.include?("user")
       end
 
       def store
-        @options.fstab_options.delete_if { |o| VALUES.include?(o) }
+        delete_from_fstab!(Regexp.union(VALUES))
 
         @options.fstab_options << "user" if value
       end
@@ -308,13 +294,10 @@ module Y2Partitioner
       end
     end
 
+    # CheckBox to enable the use of user quotas
     class Quota < CWM::CheckBox
       include FstabCommon
       VALUES = ["grpquota", "usrquota"].freeze
-
-      def initialize(options)
-        @options = options
-      end
 
       def help
         "<p><b>Enable Quota Support:</b>\n" \
@@ -327,7 +310,7 @@ module Y2Partitioner
       end
 
       def store
-        @options.fstab_options.delete_if { |o| VALUES.include?(o) }
+        delete_from_fstab!(Regexp.union(VALUES))
 
         @options.fstab_options << "usrquota" if value
         @options.fstab_options << "grpquota" if value
@@ -338,10 +321,11 @@ module Y2Partitioner
       end
     end
 
+    # ComboBox to specify the journal mode to use by the filesystem
     class JournalOptions < CWM::ComboBox
       include FstabCommon
 
-      VALUES = ["data="]
+      VALUES = ["data="].freeze
 
       def initialize(options)
         @options = options
@@ -358,7 +342,7 @@ module Y2Partitioner
       end
 
       def store
-        @options.fstab_options.delete_if { |o| o =~ /^data=/ }
+        delete_from_fstab!(/^data=/)
 
         @options.fstab_options << "data=#{value}"
       end
@@ -386,8 +370,10 @@ module Y2Partitioner
       end
     end
 
+    # Custom widget that allows to enable ACL and the use of extended
+    # attributes
     class AclOptions < CWM::CustomWidget
-      VALUES = ["acl", "eua"]
+      VALUES = ["acl", "eua"].freeze
 
       include FstabCommon
 
@@ -403,6 +389,8 @@ module Y2Partitioner
       end
     end
 
+    # A input field that allows to set other options that are not handled by
+    # specific widgets
     class ArbitraryOptions < CWM::InputField
       def initialize(options)
         @options = options
@@ -417,10 +405,9 @@ module Y2Partitioner
       end
     end
 
+    # Some options that are mainly specific for one filesystem
     class FilesystemsOptions < CWM::CustomWidget
-      def initialize(options)
-        @options = options
-      end
+      include FstabCommon
 
       def contents
         return Empty() unless widgets.any? { |w| draw_widget?(w) }
@@ -431,38 +418,30 @@ module Y2Partitioner
       def widgets
         [
           SwapPriority.new(@options),
-          IOCharset.new(@options)
+          IOCharset.new(@options),
+          Codepage.new(@options)
         ]
       end
-
-    private
-      def draw_widget?(widget)
-        return true if widget.supported_by_filesystem?
-
-        false
-      end
-
-      def draw(widget)
-        return Empty() unless draw_widget?(widget)
-
-        Left(widget)
-      end
-
     end
 
+    # Swap priority
     class SwapPriority < CWM::InputField
       include FstabCommon
-
-      def initialize(options)
-        @options = options
-      end
 
       def label
         _("Swap &Priority")
       end
 
       def init
-        42
+        i = @options.fstab_options.index { |o| o =~ /^pri=/ }
+
+        self.value = i ? @options.fstab_options[i].gsub(/^pri=/, "") : default
+      end
+
+      def store
+        delete_from_fstab!(/^pri=/)
+
+        @options.fstab_options << "pri=#{value}"
       end
 
       def validate
@@ -476,15 +455,15 @@ module Y2Partitioner
       def supported_filesystems
         [:swap]
       end
+
+      def default
+        42
+      end
     end
 
     # VFAT IOCharset
     class IOCharset < CWM::ComboBox
       include FstabCommon
-
-      def initialize(options)
-        @options = options
-      end
 
       def init
         i = @options.fstab_options.index { |o| o =~ /^iocharset=/ }
@@ -493,11 +472,10 @@ module Y2Partitioner
       end
 
       def store
-        @options.fstab_options.delete_if { |o| o =~ /^iocharset=/ }
+        delete_from_fstab!(/^iocharset/)
 
         @options.fstab_options << "iocharset=#{value}"
       end
-
 
       def label
         _("Char&set for file names")
@@ -531,5 +509,50 @@ module Y2Partitioner
       end
     end
 
+    # VFAT Codepage
+    class Codepage < CWM::ComboBox
+      include FstabCommon
+
+      def init
+        i = @options.fstab_options.index { |o| o =~ /^codepage=/ }
+
+        self.value = i ? @options.fstab_options[i].gsub(/^codepage=/, "") : default
+      end
+
+      def store
+        @options.fstab_options.delete_if { |o| o =~ /^codepage=/ }
+
+        @options.fstab_options << "codepage=#{value}"
+      end
+
+      def label
+        _("Code&page for short FAT names")
+      end
+
+      def help
+        "<p><b>Codepage for Short FAT Names:</b>\nThis codepage is used for " \
+        "converting to shortname characters on FAT file systems.</p>\n"
+      end
+
+      def opt
+        [:editable, :hstretch]
+      end
+
+      def items
+        [
+          "", "437", "852", "932", "936", "949", "950"
+        ].map do |ch|
+          [ch, ch]
+        end
+      end
+
+      def supported_filesystems
+        [:vfat]
+      end
+
+      def default
+        ""
+      end
+    end
   end
 end

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -106,7 +106,7 @@ module Y2Partitioner
       end
 
       def supported_filesystems
-        %i[btrfs ext2 ext3 ext4 reiserfs]
+        %i(btrfs ext2 ext3 ext4 reiserfs)
       end
 
     private
@@ -406,7 +406,7 @@ module Y2Partitioner
       end
 
       def opt
-        %i[hstretch]
+        %i(hstretch)
       end
 
       def label
@@ -493,7 +493,7 @@ module Y2Partitioner
       end
 
       def opt
-        %i[editable hstretch]
+        %i(editable hstretch)
       end
 
       def items
@@ -541,7 +541,7 @@ module Y2Partitioner
       end
 
       def opt
-        %i[editable hstretch]
+        %i(editable hstretch)
       end
 
       def items
@@ -553,7 +553,7 @@ module Y2Partitioner
       end
 
       def supported_filesystems
-        %i[vfat]
+        %i(vfat)
       end
 
       def default

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -227,19 +227,20 @@ module Y2Partitioner
     end
 
     # Generic checkbox for fstab options
+    # VALUES must be a pair: ["fire", "water"] means "fire" is checked and "water" unchecked
     class FstabCheckBox < CWM::CheckBox
       include FstabCommon
 
       # FIXME: It is common to almost all regexp widgets not only for checkboxes
       def init
-        self.value = @options.fstab_options.include?(check_option)
+        self.value = @options.fstab_options.include?(checked_value)
       end
 
       # FIXME: It is common to almost all regexp widgets not only for checkboxes
       def store
         delete_from_fstab!(Regexp.union(options))
 
-        @options.fstab_options << check_option if value
+        @options.fstab_options << checked_value if value
       end
 
     private
@@ -248,7 +249,7 @@ module Y2Partitioner
         self.class::VALUES
       end
 
-      def check_option
+      def checked_value
         self.class::VALUES[0]
       end
     end

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -84,11 +84,12 @@ module Y2Partitioner
       end
 
       def store
-        @options.mount_by = value
+        @options.mount_by = selected_mount_by
       end
 
       def init
-        Yast::UI.ChangeWidget(Id(:mt_group), :Value, @options.mount_by)
+        value = @options.mount_by ? @options.mount_by.to_sym : :uuid
+        Yast::UI.ChangeWidget(Id(:mt_group), :Value, value)
       end
 
       def contents
@@ -111,6 +112,12 @@ module Y2Partitioner
             )
           )
         )
+      end
+
+      def selected_mount_by
+        Y2Storage::Filesystems::MountByType.all.detect do |fs|
+          fs.to_sym == value
+        end
       end
 
       def value

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -106,7 +106,7 @@ module Y2Partitioner
       end
 
       def supported_filesystems
-        [:btrfs, :ext2, :ext3, :ext4, :reiserfs]
+        %i[btrfs ext2 ext3 ext4 reiserfs]
       end
 
     private
@@ -219,9 +219,6 @@ module Y2Partitioner
         delete_from_fstab!(Regexp.union(VALUES))
 
         @options.fstab_options << "noauto" if value
-      end
-
-      def help
       end
 
       def label
@@ -409,7 +406,7 @@ module Y2Partitioner
       end
 
       def opt
-        [:hstretch]
+        %i[hstretch]
       end
 
       def label
@@ -456,9 +453,6 @@ module Y2Partitioner
         @options.fstab_options << "pri=#{value}"
       end
 
-      def validate
-      end
-
       def help
         "<p><b>Swap Priority:</b>\nEnter the swap priority. " \
         "Higher numbers mean higher priority.</p>\n"
@@ -499,7 +493,7 @@ module Y2Partitioner
       end
 
       def opt
-        [:editable, :hstretch]
+        %i[editable hstretch]
       end
 
       def items
@@ -547,7 +541,7 @@ module Y2Partitioner
       end
 
       def opt
-        [:editable, :hstretch]
+        %i[editable hstretch]
       end
 
       def items
@@ -559,7 +553,7 @@ module Y2Partitioner
       end
 
       def supported_filesystems
-        [:vfat]
+        %i[vfat]
       end
 
       def default

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -80,7 +80,13 @@ module Y2Partitioner
       def handle(event)
         case event["ID"]
         when :help
-          Yast::Wizard.ShowHelp()
+          help = []
+
+          widgets.each do |w|
+            help << w.help if w.respond_to? "help"
+          end
+
+          Yast::Wizard.ShowHelp(help.join("\n"))
         end
 
         nil
@@ -101,6 +107,12 @@ module Y2Partitioner
 
       def supported_filesystems
         [:btrfs, :ext2, :ext3, :ext4, :reiserfs]
+      end
+
+    private
+
+      def widgets
+        Yast::CWM.widgets_in_contents([self])
       end
     end
 

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -318,7 +318,7 @@ module Y2Partitioner
       end
 
       def help
-        ("<p><b>Enable Quota Support:</b>\n" \
+        _("<p><b>Enable Quota Support:</b>\n" \
         "The file system is mounted with user quotas enabled.\n" \
         "Default is false.</p>\n")
       end

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -4,6 +4,20 @@ require "y2storage"
 
 module Y2Partitioner
   module Widgets
+    module FstabCommon
+      def supported_by_filesystem?
+        return false if !@options.filesystem_type
+
+        if self.respond_to?("supported_filesystems")
+          supported_filesystems.include?(@options.filesystem_type.to_sym)
+        else
+          self.class.const_get("VALUES").all? do |v|
+            @options.filesystem_type.supported_fstab_options.include?(v)
+          end
+        end
+      end
+    end
+
     # Push button that launch a dialog for set the fstab options
     class FstabOptionsButton < CWM::PushButton
       def initialize(options)
@@ -11,7 +25,7 @@ module Y2Partitioner
       end
 
       def label
-        _("Fstab options")
+        _("Fstab options...")
       end
 
       def handle
@@ -23,12 +37,18 @@ module Y2Partitioner
 
     # Main widget for set all the available options for a particular filesystem
     class FstabOptions < CWM::CustomWidget
+      include FstabCommon
+
       def initialize(options)
         textdomain "storage"
 
         @options = options
 
         self.handle_all_events = true
+      end
+
+      def init
+        disable if !supported_by_filesystem?
       end
 
       def help
@@ -44,14 +64,29 @@ module Y2Partitioner
           VSpacing(1),
           Left(GeneralOptions.new(@options)),
           Left(FilesystemsOptions.new(@options)),
-          VSpacing(1),
-          Left(JournalOptions.new(@options)),
-          VSpacing(1),
-          Left(AclOptions.new(@options)),
-          VSpacing(1),
+          * draw_with_vspace(JournalOptions.new(@options)),
+          * draw_with_vspace(AclOptions.new(@options)),
           Left(ArbitraryOptions.new(@options))
         )
       end
+
+      def supported_filesystems
+        [:btrfs, :ext2, :ext3, :ext4, :reiserfs]
+      end
+    private
+      def draw_widget?(widget)
+        return true if widget.supported_by_filesystem?
+
+        false
+      end
+
+      def draw_with_vspace(widget)
+        return [Empty()] unless draw_widget?(widget)
+
+        [Left(widget), VSpacing(1)]
+      end
+
+
     end
 
     class VolumeLabel < CWM::InputField
@@ -133,17 +168,37 @@ module Y2Partitioner
       end
 
       def contents
-        VBox(
-          Left(ReadOnly.new(@options)),
-          Left(Noatime.new(@options)),
-          Left(MountUser.new(@options)),
-          Left(Noauto.new(@options)),
-          Left(Quota.new(@options))
-        )
+        return Empty() unless widgets.any? { |w| draw_widget?(w) }
+
+        VBox(* widgets.map { |w| draw(w) }, VSpacing(1))
+      end
+
+      def widgets
+        [
+          ReadOnly.new(@options),
+          Noatime.new(@options),
+          MountUser.new(@options),
+          Noauto.new(@options),
+          Quota.new(@options)
+        ]
+      end
+
+    private
+      def draw_widget?(widget)
+        return true if widget.supported_by_filesystem?
+
+        false
+      end
+
+      def draw(widget)
+        return Empty() unless draw_widget?(widget)
+
+        Left(widget)
       end
     end
 
     class Noauto < CWM::CheckBox
+      include FstabCommon
       VALUES = ["noauto", "auto"].freeze
 
       def initialize(options)
@@ -169,6 +224,7 @@ module Y2Partitioner
     end
 
     class ReadOnly < CWM::CheckBox
+      include FstabCommon
       VALUES = ["rw", "ro"].freeze
 
       def initialize(options)
@@ -197,6 +253,7 @@ module Y2Partitioner
     end
 
     class Noatime < CWM::CheckBox
+      include FstabCommon
       VALUES = ["noatime", "atime"].freeze
 
       def initialize(options)
@@ -224,6 +281,7 @@ module Y2Partitioner
     end
 
     class MountUser < CWM::CheckBox
+      include FstabCommon
       VALUES = ["user", "nouser"].freeze
 
       def initialize(options)
@@ -251,6 +309,7 @@ module Y2Partitioner
     end
 
     class Quota < CWM::CheckBox
+      include FstabCommon
       VALUES = ["grpquota", "usrquota"].freeze
 
       def initialize(options)
@@ -280,6 +339,10 @@ module Y2Partitioner
     end
 
     class JournalOptions < CWM::ComboBox
+      include FstabCommon
+
+      VALUES = ["data="]
+
       def initialize(options)
         @options = options
       end
@@ -324,6 +387,10 @@ module Y2Partitioner
     end
 
     class AclOptions < CWM::CustomWidget
+      VALUES = ["acl", "eua"]
+
+      include FstabCommon
+
       def initialize(options)
         @options = options
       end
@@ -356,20 +423,36 @@ module Y2Partitioner
       end
 
       def contents
-        widgets
+        return Empty() unless widgets.any? { |w| draw_widget?(w) }
+
+        VBox(* widgets.map { |w| draw(w) }, VSpacing(1))
       end
 
       def widgets
-        case @options.filesystem
-        when Y2Storage::Filesystems::Type::SWAP
-          SwapPriority.new(@options)
-        else
-          Empty()
-        end
+        [
+          SwapPriority.new(@options),
+          IOCharset.new(@options)
+        ]
       end
+
+    private
+      def draw_widget?(widget)
+        return true if widget.supported_by_filesystem?
+
+        false
+      end
+
+      def draw(widget)
+        return Empty() unless draw_widget?(widget)
+
+        Left(widget)
+      end
+
     end
 
     class SwapPriority < CWM::InputField
+      include FstabCommon
+
       def initialize(options)
         @options = options
       end
@@ -389,6 +472,64 @@ module Y2Partitioner
         "<p><b>Swap Priority:</b>\nEnter the swap priority. " \
         "Higher numbers mean higher priority.</p>\n"
       end
+
+      def supported_filesystems
+        [:swap]
+      end
     end
+
+    # VFAT IOCharset
+    class IOCharset < CWM::ComboBox
+      include FstabCommon
+
+      def initialize(options)
+        @options = options
+      end
+
+      def init
+        i = @options.fstab_options.index { |o| o =~ /^iocharset=/ }
+
+        self.value = i ? @options.fstab_options[i].gsub(/^iocharset=/, "") : default
+      end
+
+      def store
+        @options.fstab_options.delete_if { |o| o =~ /^iocharset=/ }
+
+        @options.fstab_options << "iocharset=#{value}"
+      end
+
+
+      def label
+        _("Char&set for file names")
+      end
+
+      def help
+        "<p><b>Charset for File Names:</b>\nSet the charset used for display " \
+        "of file names in Windows partitions.</p>\n"
+      end
+
+      def opt
+        [:editable, :hstretch]
+      end
+
+      def items
+        [
+          "", "iso8859-1", "iso8859-15", "iso8859-2", "iso8859-5", "iso8859-7",
+          "iso8859-9", "utf8", "koi8-r", "euc-jp", "sjis", "gb2312", "big5",
+          "euc-kr"
+        ].map do |ch|
+          [ch, ch]
+        end
+      end
+
+      def supported_filesystems
+        [:vfat]
+      end
+
+      def default
+        ""
+      end
+    end
+
   end
 end

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -1,0 +1,387 @@
+require "yast"
+require "cwm"
+require "y2storage"
+
+module Y2Partitioner
+  module Widgets
+    # Push button that launch a dialog for set the fstab options
+    class FstabOptionsButton < CWM::PushButton
+      def initialize(options)
+        @options = options
+      end
+
+      def label
+        _("Fstab options")
+      end
+
+      def handle
+        Dialogs::FstabOptions.new(@options).run
+
+        nil
+      end
+    end
+
+    # Main widget for set all the available options for a particular filesystem
+    class FstabOptions < CWM::CustomWidget
+      def initialize(options)
+        textdomain "storage"
+
+        @options = options
+
+        self.handle_all_events = true
+      end
+
+      def help
+      end
+
+      def store
+      end
+
+      def contents
+        VBox(
+          Left(MountBy.new(@options)),
+          Left(VolumeLabel.new(@options)),
+          VSpacing(1),
+          Left(GeneralOptions.new(@options)),
+          Left(FilesystemsOptions.new(@options)),
+          VSpacing(1),
+          Left(JournalOptions.new(@options)),
+          VSpacing(1),
+          Left(AclOptions.new(@options)),
+          VSpacing(1),
+          Left(ArbitraryOptions.new(@options))
+        )
+      end
+    end
+
+    class VolumeLabel < CWM::InputField
+      def initialize(options)
+        @options = options
+      end
+
+      def label
+        _("Volume &Label")
+      end
+
+      def store
+        @options.label = value
+      end
+
+      def init
+        self.value = @options.label
+      end
+    end
+
+    class MountBy < CWM::CustomWidget
+      def initialize(options)
+        textdomain "storage"
+
+        @options = options
+      end
+
+      def label
+        _("Mount in /etc/fstab by")
+      end
+
+      def store
+        @options.mount_by = value
+      end
+
+      def init
+        Yast::UI.ChangeWidget(Id(:mt_group), :Value, @options.mount_by)
+      end
+
+      def contents
+        RadioButtonGroup(
+          Id(:mt_group),
+          VBox(
+            Left(Label(label)),
+            HBox(
+              VBox(
+                Left(RadioButton(Id(:device), _("&Device Name"))),
+                Left(RadioButton(Id(:label), _("Volume &Label"))),
+                Left(RadioButton(Id(:uuid), _("&UUID")))
+              ),
+              Top(
+                VBox(
+                  Left(RadioButton(Id(:id), _("Device &ID"))),
+                  Left(RadioButton(Id(:path), _("Device &Path")))
+                )
+              )
+            )
+          )
+        )
+      end
+
+      def value
+        Yast::UI.QueryWidget(Id(:mt_group), :Value)
+      end
+    end
+
+    class GeneralOptions < CWM::CustomWidget
+      def initialize(options)
+        textdomain "storage"
+
+        @options = options
+      end
+
+      def contents
+        VBox(
+          Left(ReadOnly.new(@options)),
+          Left(Noatime.new(@options)),
+          Left(MountUser.new(@options)),
+          Left(Noauto.new(@options)),
+          Left(Quota.new(@options))
+        )
+      end
+    end
+
+    class Noauto < CWM::CheckBox
+      VALUES = ["noauto", "auto"].freeze
+
+      def initialize(options)
+        @options = options
+      end
+
+      def init
+        self.value = @options.fstab_options.include?("noauto")
+      end
+
+      def store
+        @options.fstab_options.delete_if { |o| VALUES.include?(o) }
+
+        @options.fstab_options << "noauto" if value
+      end
+
+      def help
+      end
+
+      def label
+        _("Do Not Mount at System &Start-up")
+      end
+    end
+
+    class ReadOnly < CWM::CheckBox
+      VALUES = ["rw", "ro"].freeze
+
+      def initialize(options)
+        @options = options
+      end
+
+      def init
+        self.value = @options.fstab_options.include?("ro")
+      end
+
+      def store
+        @options.fstab_options.delete_if { |o| VALUES.include?(o) }
+
+        @options.fstab_options << "ro" if value
+      end
+
+      def help
+        "<p><b>Mount Read-Only:</b>\n" \
+        "Writing to the file system is not possible. Default is false. During installation\n" \
+        "the file system is always mounted read-write.</p>"
+      end
+
+      def label
+        _("Mount &Read-Only")
+      end
+    end
+
+    class Noatime < CWM::CheckBox
+      VALUES = ["noatime", "atime"].freeze
+
+      def initialize(options)
+        @options = options
+      end
+
+      def init
+        self.value = @options.fstab_options.include?("noatime")
+      end
+
+      def store
+        @options.fstab_options.delete_if { |o| VALUES.include?(o) }
+
+        @options.fstab_options << "noatime" if value
+      end
+
+      def help
+        "<p><b>No Access Time:</b>\nAccess times are not " \
+        "updated when a file is read. Default is false.</p>\n"
+      end
+
+      def label
+        _("No &Access Time")
+      end
+    end
+
+    class MountUser < CWM::CheckBox
+      VALUES = ["user", "nouser"].freeze
+
+      def initialize(options)
+        @options = options
+      end
+
+      def init
+        self.value = @options.fstab_options.include?("user")
+      end
+
+      def store
+        @options.fstab_options.delete_if { |o| VALUES.include?(o) }
+
+        @options.fstab_options << "user" if value
+      end
+
+      def help
+        "<p><b>Mountable by User:</b>\nThe file system may be " \
+        "mounted by an ordinary user. Default is false.</p>\n"
+      end
+
+      def label
+        _("Mountable by user")
+      end
+    end
+
+    class Quota < CWM::CheckBox
+      VALUES = ["grpquota", "usrquota"].freeze
+
+      def initialize(options)
+        @options = options
+      end
+
+      def help
+        "<p><b>Enable Quota Support:</b>\n" \
+        "The file system is mounted with user quotas enabled.\n" \
+        "Default is false.</p>\n"
+      end
+
+      def init
+        self.value = @options.fstab_options.any? { |o| VALUES.include?(o) }
+      end
+
+      def store
+        @options.fstab_options.delete_if { |o| VALUES.include?(o) }
+
+        @options.fstab_options << "usrquota" if value
+        @options.fstab_options << "grpquota" if value
+      end
+
+      def label
+        _("Enable &Quota Support")
+      end
+    end
+
+    class JournalOptions < CWM::ComboBox
+      def initialize(options)
+        @options = options
+      end
+
+      def label
+        _("Data &Journaling Mode")
+      end
+
+      def init
+        i = @options.fstab_options.index { |o| o =~ /^data=/ }
+
+        self.value = i ? @options.fstab_options[i].gsub(/^data=/, "") : default
+      end
+
+      def store
+        @options.fstab_options.delete_if { |o| o =~ /^data=/ }
+
+        @options.fstab_options << "data=#{value}"
+      end
+
+      def items
+        [
+          ["journal", "journal"],
+          ["ordered", "ordered"],
+          ["writeback", "writeback"]
+        ]
+      end
+
+      def help
+        "<p><b>Data Journaling Mode:</b>\n" \
+        "Specifies the journaling mode for file data.\n" \
+        "<tt>journal</tt> -- All data is committed to the journal prior to being\n" \
+        "written into the main file system. Highest performance impact.<br>\n" \
+        "<tt>ordered</tt> -- All data is forced directly out to the main file system\n" \
+        "prior to its metadata being committed to the journal. Medium performance impact.<br>\n" \
+        "<tt>writeback</tt> -- Data ordering is not preserved. No performance impact.</p>\n"
+      end
+
+      def default
+        "journal"
+      end
+    end
+
+    class AclOptions < CWM::CustomWidget
+      def initialize(options)
+        @options = options
+      end
+
+      def contents
+        VBox(
+          Left(CheckBox(Id("opt_acl"), _("&Access Control Lists (ACL)"), false)),
+          Left(CheckBox(Id("opt_eua"), _("&Extended User Attributes"), false))
+        )
+      end
+    end
+
+    class ArbitraryOptions < CWM::InputField
+      def initialize(options)
+        @options = options
+      end
+
+      def opt
+        [:hstretch]
+      end
+
+      def label
+        _("Arbitrary Option &Value")
+      end
+    end
+
+    class FilesystemsOptions < CWM::CustomWidget
+      def initialize(options)
+        @options = options
+      end
+
+      def contents
+        widgets
+      end
+
+      def widgets
+        case @options.filesystem
+        when Y2Storage::Filesystems::Type::SWAP
+          SwapPriority.new(@options)
+        else
+          Empty()
+        end
+      end
+    end
+
+    class SwapPriority < CWM::InputField
+      def initialize(options)
+        @options = options
+      end
+
+      def label
+        _("Swap &Priority")
+      end
+
+      def init
+        42
+      end
+
+      def validate
+      end
+
+      def help
+        "<p><b>Swap Priority:</b>\nEnter the swap priority. " \
+        "Higher numbers mean higher priority.</p>\n"
+      end
+    end
+  end
+end

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -273,9 +273,9 @@ module Y2Partitioner
       end
 
       def help
-        "<p><b>Mount Read-Only:</b>\n" \
+        _("<p><b>Mount Read-Only:</b>\n" \
         "Writing to the file system is not possible. Default is false. During installation\n" \
-        "the file system is always mounted read-write.</p>"
+        "the file system is always mounted read-write.</p>")
       end
     end
 
@@ -288,8 +288,8 @@ module Y2Partitioner
       end
 
       def help
-        "<p><b>No Access Time:</b>\nAccess times are not " \
-        "updated when a file is read. Default is false.</p>\n"
+        _("<p><b>No Access Time:</b>\nAccess times are not " \
+        "updated when a file is read. Default is false.</p>\n")
       end
     end
 
@@ -303,8 +303,8 @@ module Y2Partitioner
       end
 
       def help
-        "<p><b>Mountable by User:</b>\nThe file system may be " \
-        "mounted by an ordinary user. Default is false.</p>\n"
+        _("<p><b>Mountable by User:</b>\nThe file system may be " \
+        "mounted by an ordinary user. Default is false.</p>\n")
       end
     end
 
@@ -318,9 +318,9 @@ module Y2Partitioner
       end
 
       def help
-        "<p><b>Enable Quota Support:</b>\n" \
+        ("<p><b>Enable Quota Support:</b>\n" \
         "The file system is mounted with user quotas enabled.\n" \
-        "Default is false.</p>\n"
+        "Default is false.</p>\n")
       end
 
       def init
@@ -361,13 +361,13 @@ module Y2Partitioner
       end
 
       def help
-        "<p><b>Data Journaling Mode:</b>\n" \
+        _("<p><b>Data Journaling Mode:</b>\n" \
         "Specifies the journaling mode for file data.\n" \
         "<tt>journal</tt> -- All data is committed to the journal prior to being\n" \
         "written into the main file system. Highest performance impact.<br>\n" \
         "<tt>ordered</tt> -- All data is forced directly out to the main file system\n" \
         "prior to its metadata being committed to the journal. Medium performance impact.<br>\n" \
-        "<tt>writeback</tt> -- Data ordering is not preserved. No performance impact.</p>\n"
+        "<tt>writeback</tt> -- Data ordering is not preserved. No performance impact.</p>\n")
       end
     end
 
@@ -382,8 +382,8 @@ module Y2Partitioner
 
       def contents
         VBox(
-          Left(CheckBox(Id("opt_acl"), _("&Access Control Lists (ACL)"), false)),
-          Left(CheckBox(Id("opt_eua"), _("&Extended User Attributes"), false))
+          Left(CheckBox(Id("opt_acl"), Opt(:disabled), _("&Access Control Lists (ACL)"), false)),
+          Left(CheckBox(Id("opt_eua"), Opt(:disabled), _("&Extended User Attributes"), false))
         )
       end
     end
@@ -400,7 +400,7 @@ module Y2Partitioner
       end
 
       def opt
-        %i(hstretch)
+        %i(hstretch disabled)
       end
 
       def label
@@ -446,8 +446,8 @@ module Y2Partitioner
       end
 
       def help
-        "<p><b>Swap Priority:</b>\nEnter the swap priority. " \
-        "Higher numbers mean higher priority.</p>\n"
+        _("<p><b>Swap Priority:</b>\nEnter the swap priority. " \
+        "Higher numbers mean higher priority.</p>\n")
       end
     end
 
@@ -481,8 +481,8 @@ module Y2Partitioner
       end
 
       def help
-        "<p><b>Charset for File Names:</b>\nSet the charset used for display " \
-        "of file names in Windows partitions.</p>\n"
+        _("<p><b>Charset for File Names:</b>\nSet the charset used for display " \
+        "of file names in Windows partitions.</p>\n")
       end
 
       def opt
@@ -516,8 +516,8 @@ module Y2Partitioner
       end
 
       def help
-        "<p><b>Codepage for Short FAT Names:</b>\nThis codepage is used for " \
-        "converting to shortname characters on FAT file systems.</p>\n"
+        _("<p><b>Codepage for Short FAT Names:</b>\nThis codepage is used for " \
+        "converting to shortname characters on FAT file systems.</p>\n")
       end
 
       def opt

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -360,9 +360,9 @@ module Y2Partitioner
 
       def items
         [
-          ["journal", "journal"],
-          ["ordered", "ordered"],
-          ["writeback", "writeback"]
+          ["journal", _("journal")],
+          ["ordered", _("ordered")],
+          ["writeback", _("writeback")]
         ]
       end
 
@@ -380,7 +380,7 @@ module Y2Partitioner
     # Custom widget that allows to enable ACL and the use of extended
     # attributes
     #
-    # FIXME: Pending implementation, currently it is only draw
+    # TODO: FIXME: Pending implementation, currently it is only draw
     class AclOptions < CWM::CustomWidget
       include FstabCommon
 
@@ -397,7 +397,7 @@ module Y2Partitioner
     # A input field that allows to set other options that are not handled by
     # specific widgets
     #
-    # FIXME: Pending implementation, currently it is only draw, all the options
+    # TODO: FIXME: Pending implementation, currently it is only draw, all the options
     # that it is responsable of should be defined, removing them if not set or
     # supported by the current filesystem.
     class ArbitraryOptions < CWM::InputField
@@ -464,6 +464,11 @@ module Y2Partitioner
       SUPPORTED_FILESYSTEMS = ["vfat"].freeze
       REGEXP = /^iocharset=/
       DEFAULT = "".freeze
+      AVAILABLE_VALUES = [
+          "", "iso8859-1", "iso8859-15", "iso8859-2", "iso8859-5", "iso8859-7",
+          "iso8859-9", "utf8", "koi8-r", "euc-jp", "sjis", "gb2312", "big5",
+          "euc-kr"
+        ].freeze
 
       def init
         i = @options.fstab_options.index { |o| o =~ REGEXP }
@@ -491,11 +496,7 @@ module Y2Partitioner
       end
 
       def items
-        [
-          "", "iso8859-1", "iso8859-15", "iso8859-2", "iso8859-5", "iso8859-7",
-          "iso8859-9", "utf8", "koi8-r", "euc-jp", "sjis", "gb2312", "big5",
-          "euc-kr"
-        ].map do |ch|
+        AVAILABLE_VALUES.map do |ch|
           [ch, ch]
         end
       end

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -35,17 +35,9 @@ module Y2Partitioner
       end
 
       # @param widget [CWM::AbstractWidget]
-      # @return [Boolean] true if it is supported by current filesystem
-      def ui_term?(widget)
-        return true if widget.supported_by_filesystem?
-
-        false
-      end
-
-      # @param widget [CWM::AbstractWidget]
       # @return [CWM::WidgetTerm]
       def to_ui_term(widget)
-        return Empty() unless ui_term?(widget)
+        return Empty() unless widget.supported_by_filesystem?
 
         Left(widget)
       end
@@ -53,7 +45,7 @@ module Y2Partitioner
       # @param widget [CWM::AbstractWidget]
       # @return [Array<CWM::WidgetTerm>]
       def ui_term_with_vspace(widget)
-        return [Empty()] unless ui_term?(widget)
+        return [Empty()] unless widget.supported_by_filesystem?
 
         [Left(widget), VSpacing(1)]
       end
@@ -127,6 +119,7 @@ module Y2Partitioner
       def contents
         VBox(
           Left(MountBy.new(@options)),
+          VSpacing(1),
           Left(VolumeLabel.new(@options)),
           VSpacing(1),
           Left(GeneralOptions.new(@options)),
@@ -217,7 +210,7 @@ module Y2Partitioner
       include FstabCommon
 
       def contents
-        return Empty() unless widgets.any? { |w| ui_term?(w) }
+        return Empty() unless widgets.any? { |w| w.supported_by_filesystem? }
 
         VBox(* widgets.map { |w| to_ui_term(w) }, VSpacing(1))
       end
@@ -419,7 +412,7 @@ module Y2Partitioner
       include FstabCommon
 
       def contents
-        return Empty() unless widgets.any? { |w| ui_term?(w) }
+        return Empty() unless widgets.any? { |w| w.supported_by_filesystem? }
 
         VBox(* widgets.map { |w| to_ui_term(w) }, VSpacing(1))
       end

--- a/src/lib/y2partitioner/widgets/fstab_options.rb
+++ b/src/lib/y2partitioner/widgets/fstab_options.rb
@@ -210,7 +210,7 @@ module Y2Partitioner
       include FstabCommon
 
       def contents
-        return Empty() unless widgets.any? { |w| w.supported_by_filesystem? }
+        return Empty() unless widgets.any?(&:supported_by_filesystem?)
 
         VBox(* widgets.map { |w| to_ui_term(w) }, VSpacing(1))
       end
@@ -412,7 +412,7 @@ module Y2Partitioner
       include FstabCommon
 
       def contents
-        return Empty() unless widgets.any? { |w| w.supported_by_filesystem? }
+        return Empty() unless widgets.any?(&:supported_by_filesystem?)
 
         VBox(* widgets.map { |w| to_ui_term(w) }, VSpacing(1))
       end
@@ -458,10 +458,10 @@ module Y2Partitioner
       REGEXP = /^iocharset=/
       DEFAULT = "".freeze
       AVAILABLE_VALUES = [
-          "", "iso8859-1", "iso8859-15", "iso8859-2", "iso8859-5", "iso8859-7",
-          "iso8859-9", "utf8", "koi8-r", "euc-jp", "sjis", "gb2312", "big5",
-          "euc-kr"
-        ].freeze
+        "", "iso8859-1", "iso8859-15", "iso8859-2", "iso8859-5", "iso8859-7",
+        "iso8859-9", "utf8", "koi8-r", "euc-jp", "sjis", "gb2312", "big5",
+        "euc-kr"
+      ].freeze
 
       def init
         i = @options.fstab_options.index { |o| o =~ REGEXP }

--- a/src/lib/y2partitioner/widgets/partition_page.rb
+++ b/src/lib/y2partitioner/widgets/partition_page.rb
@@ -55,7 +55,7 @@ module Y2Partitioner
 
       # @macro seeAbstractWidget
       def label
-        @partition.name.split("/").last
+        @partition.basename
       end
 
       # @macro seeCustomWidget

--- a/src/lib/y2partitioner/yard_links.rb
+++ b/src/lib/y2partitioner/yard_links.rb
@@ -16,6 +16,10 @@ module Y2Storage
   class Devicegraph
   end
 
+  # See http://www.rubydoc.info/github/yast/yast-storage-ng/Y2Storage/BlkDevice
+  class BlkDevice
+  end
+
   # See http://www.rubydoc.info/github/yast/yast-storage-ng/Y2Storage/Region
   class Region
   end

--- a/test/dialogs/encrypt_password_test.rb
+++ b/test/dialogs/encrypt_password_test.rb
@@ -1,0 +1,12 @@
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/dialogs/encrypt_password"
+
+describe Y2Partitioner::Dialogs::EncryptPassword do
+  let(:options) { double("Format Options", name: "/dev/test_part") }
+
+  subject { described_class.new(options) }
+
+  include_examples "CWM::Dialog"
+end

--- a/test/dialogs/format_and_mount_test.rb
+++ b/test/dialogs/format_and_mount_test.rb
@@ -1,0 +1,12 @@
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/dialogs/format_and_mount"
+
+describe Y2Partitioner::Dialogs::FormatAndMount do
+  let(:options) { double("Format Options", name: "/dev/test_part") }
+
+  subject { described_class.new(options) }
+
+  include_examples "CWM::Dialog"
+end

--- a/test/dialogs/fstab_options_test.rb
+++ b/test/dialogs/fstab_options_test.rb
@@ -1,0 +1,12 @@
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/dialogs/fstab_options"
+
+describe Y2Partitioner::Dialogs::FstabOptions do
+  let(:options) { double("Format Options") }
+
+  subject { described_class.new(options) }
+
+  include_examples "CWM::Dialog"
+end

--- a/test/dialogs/partition_role_test.rb
+++ b/test/dialogs/partition_role_test.rb
@@ -1,0 +1,17 @@
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/dialogs/partition_role"
+
+describe Y2Partitioner::Dialogs::PartitionRole do
+  let(:options) { double("Format Options", name: "/dev/test_part") }
+
+  before do
+    allow(Y2Partitioner::Dialogs::PartitionRole::RoleChoice)
+      .to receive(:new).and_return(term(:Empty))
+  end
+
+  subject { described_class.new("mydisk", options) }
+
+  include_examples "CWM::Dialog"
+end

--- a/test/format_and_mount_test.rb
+++ b/test/format_and_mount_test.rb
@@ -1,0 +1,125 @@
+require_relative "test_helper"
+
+require "y2partitioner/format_mount_options"
+
+describe Y2Partitioner::FormatMountOptions do
+
+  context "#initialize" do
+    it "sets the defauts options" do
+      expect_any_instance_of(Y2Partitioner::FormatMountOptions).to receive(:set_defaults!)
+
+      subject
+    end
+
+    context "when a specific role is given" do
+      it "also set options for the specific role" do
+        expect_any_instance_of(Y2Partitioner::FormatMountOptions)
+          .to receive(:set_defaults!)
+        expect_any_instance_of(Y2Partitioner::FormatMountOptions)
+          .to receive(:options_for_role).with(:swap)
+
+        Y2Partitioner::FormatMountOptions.new(role: :swap)
+      end
+    end
+
+    context "when a specific partition is given" do
+      let(:partition) { instance_double(Y2Storage::Partition, name: "/dev/test_partition") }
+
+      it "also set options for the specific partition" do
+        expect_any_instance_of(Y2Partitioner::FormatMountOptions)
+          .to receive(:set_defaults!)
+        expect_any_instance_of(Y2Partitioner::FormatMountOptions)
+          .to receive(:options_for_partition).with(partition)
+
+        Y2Partitioner::FormatMountOptions.new(partition: partition)
+      end
+    end
+  end
+
+  context "#options_for_role" do
+    let(:options) { Y2Partitioner::FormatMountOptions.new }
+
+    context "when the given role is :swap" do
+      before do
+        options.options_for_role(:swap)
+      end
+
+      it "sets the partition_id as Y2Storage::PartitionId::SWAP" do
+        expect(options.partition_id).to eql(Y2Storage::PartitionId::SWAP)
+      end
+
+      it "sets the filesystem as swap" do
+        expect(options.filesystem_type).to eql(Y2Storage::Filesystems::Type::SWAP)
+      end
+
+      it "sets the mount_point as swap" do
+        expect(options.mount_point).to eql("swap")
+      end
+    end
+
+    context "when the given role is :efi_boot" do
+      before do
+        options.options_for_role(:efi_boot)
+      end
+
+      it "sets the partition_id as Y2Storage::PartitionId::ESP" do
+        expect(options.partition_id).to eql(Y2Storage::PartitionId::ESP)
+      end
+
+      it "sets the filesystem as VFAT" do
+        expect(options.filesystem_type).to eql(Y2Storage::Filesystems::Type::VFAT)
+      end
+
+      it "sets the mount_point as /boot/efi" do
+        expect(options.mount_point).to eql("/boot/efi")
+      end
+    end
+
+    context "when the given role is :system" do
+      before do
+        options.options_for_role(:system)
+      end
+      it "sets the partition_id as Y2Storage::PartitionId::LINUX" do
+        expect(options.partition_id).to eql(Y2Storage::PartitionId::LINUX)
+      end
+
+      it "sets the filesystem with the default" do
+        expect(options.filesystem_type).to eql(options.default_fs)
+      end
+    end
+  end
+
+  context "#options_for_partition" do
+    let(:options) { Y2Partitioner::FormatMountOptions.new }
+    let(:filesystem) { instance_double(Y2Storage::Filesystems::Type) }
+    let(:partition) do
+      instance_double(
+        Y2Storage::Partition,
+        name:       "/dev/test_partition",
+        id:         Y2Storage::PartitionId::LVM,
+        type:       "primary",
+        filesystem: filesystem
+      )
+    end
+
+    before do
+      allow(options).to receive(:options_for_filesystem)
+    end
+
+    context "given a partition" do
+      it "sets the name, type and partition_id options from the partition" do
+        options.options_for_partition(partition)
+
+        expect(options.name).to eql("/dev/test_partition")
+        expect(options.partition_id).to eql(Y2Storage::PartitionId::LVM)
+        expect(options.partition_type).to eql("primary")
+      end
+
+      it "sets the rest of options based on its filesystem" do
+        expect(options).to receive(:options_for_filesystem).with(filesystem)
+
+        options.options_for_partition(partition)
+      end
+    end
+  end
+end

--- a/test/format_and_mount_test.rb
+++ b/test/format_and_mount_test.rb
@@ -84,7 +84,7 @@ describe Y2Partitioner::FormatMountOptions do
       end
 
       it "sets the filesystem with the default" do
-        expect(options.filesystem_type).to eql(options.default_fs)
+        expect(options.filesystem_type).to eql(Y2Partitioner::FormatMountOptions::DEFAULT_FS)
       end
     end
   end

--- a/test/format_mount/base_test.rb
+++ b/test/format_mount/base_test.rb
@@ -1,0 +1,103 @@
+require_relative "../test_helper"
+
+require "y2partitioner/format_mount/options"
+
+describe Y2Partitioner::FormatMount::Base do
+  let(:subject) { described_class.new(partition, options) }
+  let(:options) { Y2Partitioner::FormatMount::Options.new }
+  let(:filesystem) { instance_double(Y2Storage::Filesystems::Type) }
+  let(:partition) do
+    instance_double(
+      Y2Storage::Partition,
+      name:       "/dev/test_partition",
+      basename:   "test_partition",
+      id:         Y2Storage::PartitionId::LVM,
+      type:       "primary",
+      filesystem: filesystem
+    )
+  end
+
+  context "#apply_options!" do
+    before do
+      allow(partition).to receive(:id=)
+      allow(subject).to receive(:apply_format_options!)
+      allow(subject).to receive(:apply_mount_options!)
+    end
+
+    it "sets the partition id" do
+      expect(partition).to receive(:id=)
+
+      subject.apply_options!
+    end
+
+    it "applies format options over the partition" do
+      expect(subject).to receive(:apply_format_options!)
+      subject.apply_options!
+    end
+
+    it "applies mount options over the partition" do
+      expect(subject).to receive(:apply_mount_options!)
+
+      subject.apply_options!
+    end
+
+  end
+
+  context "#apply_format_options!" do
+    let(:encrypted) { instance_double(Y2Storage::Encryption) }
+
+    before do
+      allow(partition).to receive(:remove_descendants)
+      allow(partition).to receive(:create_filesystem)
+      allow(partition).to receive(:create_encryption)
+    end
+
+    context "when the partition has not been set to be formated or encrypted" do
+      it "returns false" do
+        expect(subject.apply_format_options!).to eql(false)
+      end
+    end
+
+    context "when the partition has been set to be formated or encrypted" do
+      before do
+        allow(options).to receive(:format).and_return(true)
+      end
+
+      it "removes all partition descendants" do
+        expect(partition).to receive(:remove_descendants)
+
+        subject.apply_format_options!
+      end
+
+      it "encrypts the partition if encrypted has been selected" do
+        allow(options).to receive(:format).and_return(false)
+        allow(options).to receive(:encrypt).and_return(true)
+        allow(options).to receive(:password).and_return("LOTP_password")
+        expect(partition).to receive(:create_encryption).with("cr_#{partition.basename}")
+          .and_return(encrypted)
+        expect(encrypted).to receive(:password=).with("LOTP_password")
+
+        subject.apply_format_options!
+      end
+
+      it "creates a new filesystem with the filesystem type configured if formated" do
+        allow(options).to receive(:filesystem_type).and_return(filesystem)
+        expect(partition).to receive(:create_filesystem).with(filesystem)
+
+        subject.apply_format_options!
+      end
+
+      it "returns true" do
+        expect(subject.apply_format_options!).to eql(true)
+      end
+    end
+
+  end
+
+  context "#apply_mount_options!" do
+    it "returns false if partition does not have" do
+    end
+    it "empties partition filesystem mountpoint in case of no mount option" do
+    end
+  end
+end

--- a/test/format_mount/options_test.rb
+++ b/test/format_mount/options_test.rb
@@ -1,24 +1,24 @@
-require_relative "test_helper"
+require_relative "../test_helper"
 
-require "y2partitioner/format_mount_options"
+require "y2partitioner/format_mount/options"
 
-describe Y2Partitioner::FormatMountOptions do
+describe Y2Partitioner::FormatMount::Options do
 
   context "#initialize" do
     it "sets the defauts options" do
-      expect_any_instance_of(Y2Partitioner::FormatMountOptions).to receive(:set_defaults!)
+      expect_any_instance_of(described_class).to receive(:set_defaults!)
 
       subject
     end
 
     context "when a specific role is given" do
       it "also set options for the specific role" do
-        expect_any_instance_of(Y2Partitioner::FormatMountOptions)
+        expect_any_instance_of(described_class)
           .to receive(:set_defaults!)
-        expect_any_instance_of(Y2Partitioner::FormatMountOptions)
+        expect_any_instance_of(described_class)
           .to receive(:options_for_role).with(:swap)
 
-        Y2Partitioner::FormatMountOptions.new(role: :swap)
+        described_class.new(role: :swap)
       end
     end
 
@@ -26,18 +26,18 @@ describe Y2Partitioner::FormatMountOptions do
       let(:partition) { instance_double(Y2Storage::Partition, name: "/dev/test_partition") }
 
       it "also set options for the specific partition" do
-        expect_any_instance_of(Y2Partitioner::FormatMountOptions)
+        expect_any_instance_of(described_class)
           .to receive(:set_defaults!)
-        expect_any_instance_of(Y2Partitioner::FormatMountOptions)
+        expect_any_instance_of(described_class)
           .to receive(:options_for_partition).with(partition)
 
-        Y2Partitioner::FormatMountOptions.new(partition: partition)
+        described_class.new(partition: partition)
       end
     end
   end
 
   context "#options_for_role" do
-    let(:options) { Y2Partitioner::FormatMountOptions.new }
+    let(:options) { described_class.new }
 
     context "when the given role is :swap" do
       before do
@@ -84,13 +84,13 @@ describe Y2Partitioner::FormatMountOptions do
       end
 
       it "sets the filesystem with the default" do
-        expect(options.filesystem_type).to eql(Y2Partitioner::FormatMountOptions::DEFAULT_FS)
+        expect(options.filesystem_type).to eql(described_class::DEFAULT_FS)
       end
     end
   end
 
   context "#options_for_partition" do
-    let(:options) { Y2Partitioner::FormatMountOptions.new }
+    let(:options) { described_class.new }
     let(:filesystem) { instance_double(Y2Storage::Filesystems::Type) }
     let(:partition) do
       instance_double(

--- a/test/widgets/format_and_mount_test.rb
+++ b/test/widgets/format_and_mount_test.rb
@@ -4,30 +4,39 @@ require "cwm/rspec"
 require "y2partitioner/widgets/format_and_mount"
 
 describe Y2Partitioner::Widgets::FormatOptions do
-  let(:blk_device) do
-    double("Block Device", filesystem_type: "Ext9")
+  let(:format_options) do
+    double("Format Options", filesystem_type: Y2Storage::Filesystems::Type::XFS,
+           format: false, encrypt: false)
   end
-  subject { described_class.new(blk_device) }
+  subject { described_class.new(format_options) }
 
   include_examples "CWM::CustomWidget"
 end
 
 describe Y2Partitioner::Widgets::MountOptions do
-  let(:blk_device) do
-    double("Block Device", filesystem_mountpoint: "/foo", filesystem: nil)
+  let(:format_options) do
+    double("Format Options", filesystem_mountpoint: "/foo",
+                             filesystem_type:       Y2Storage::Filesystems::Type::XFS)
   end
-  subject { described_class.new(blk_device) }
+  subject { described_class.new(format_options) }
 
   include_examples "CWM::CustomWidget"
 end
 
 describe Y2Partitioner::Widgets::FstabOptionsButton do
-  subject { described_class.new("some options") }
-  include_examples "CWM::PushButton"
-
-  describe "#layout" do
-    it "produces a Term" do
-      expect(subject.layout).to be_a Yast::Term
-    end
+  let(:format_options) do
+    double("Format Options")
+    # double("Format Options", filesystem_type: Y2Storage::Filesystems::Type::XFS,
+    #        format: true, encrypt: false, mount_by: :label, label: "data", :
+    #        mount_point => "swap", :fstab_options => [])
   end
+
+  before do
+    allow(Y2Partitioner::Dialogs::FstabOptions)
+      .to receive(:new).and_return(double(run: :next))
+  end
+
+  subject { described_class.new(format_options) }
+
+  include_examples "CWM::PushButton"
 end

--- a/test/widgets/format_and_mount_test.rb
+++ b/test/widgets/format_and_mount_test.rb
@@ -26,9 +26,6 @@ end
 describe Y2Partitioner::Widgets::FstabOptionsButton do
   let(:format_options) do
     double("Format Options")
-    # double("Format Options", filesystem_type: Y2Storage::Filesystems::Type::XFS,
-    #        format: true, encrypt: false, mount_by: :label, label: "data", :
-    #        mount_point => "swap", :fstab_options => [])
   end
 
   before do
@@ -39,4 +36,54 @@ describe Y2Partitioner::Widgets::FstabOptionsButton do
   subject { described_class.new(format_options) }
 
   include_examples "CWM::PushButton"
+end
+
+describe Y2Partitioner::Widgets::BlkDeviceFilesystem do
+  let(:format_options) do
+    double("Format Options")
+  end
+
+  subject { described_class.new(format_options) }
+
+  include_examples "CWM::AbstractWidget"
+end
+
+describe Y2Partitioner::Widgets::MountPoint do
+  let(:format_options) do
+    double("Format Options")
+  end
+
+  subject { described_class.new(format_options) }
+
+  include_examples "CWM::AbstractWidget"
+end
+
+describe Y2Partitioner::Widgets::InodeSize do
+  let(:format_options) do
+    double("Format Options")
+  end
+
+  subject { described_class.new(format_options) }
+
+  include_examples "CWM::AbstractWidget"
+end
+
+describe Y2Partitioner::Widgets::BlockSize do
+  let(:format_options) do
+    double("Format Options")
+  end
+
+  subject { described_class.new(format_options) }
+
+  include_examples "CWM::AbstractWidget"
+end
+
+describe Y2Partitioner::Widgets::PartitionId do
+  let(:format_options) do
+    double("Format Options")
+  end
+
+  subject { described_class.new(format_options) }
+
+  include_examples "CWM::AbstractWidget"
 end

--- a/test/widgets/fstab_options_test.rb
+++ b/test/widgets/fstab_options_test.rb
@@ -1,0 +1,109 @@
+require_relative "../test_helper"
+
+require "cwm/rspec"
+require "y2partitioner/widgets/fstab_options"
+
+RSpec.shared_examples "CWM::AbstractWidget#init#store" do
+  describe "#init" do
+    it "does not crash" do
+      next unless subject.respond_to?(:init)
+      expect { subject.init }.to_not raise_error
+    end
+  end
+
+  describe "#store" do
+    it "does not crash" do
+      next unless subject.respond_to?(:store)
+      expect { subject.store }.to_not raise_error
+    end
+  end
+end
+
+RSpec.shared_examples "CWM::InputField" do
+  include_examples "CWM::AbstractWidget"
+  include_examples "CWM::ValueBasedWidget"
+  include_examples "CWM::AbstractWidget#init#store"
+end
+
+RSpec.shared_examples "CWM::CheckBox" do
+  include_examples "CWM::AbstractWidget"
+  include_examples "CWM::ValueBasedWidget"
+  include_examples "CWM::AbstractWidget#init#store"
+end
+
+RSpec.shared_examples "FstabCheckBox" do
+  include_examples "CWM::CheckBox"
+end
+
+describe Y2Partitioner::Widgets do
+  let(:options) { Y2Partitioner::FormatMount::Options.new }
+  subject { described_class.new(options) }
+
+  describe Y2Partitioner::Widgets::FstabOptions do
+    include_examples "CWM::CustomWidget"
+  end
+
+  describe Y2Partitioner::Widgets::VolumeLabel do
+    include_examples "CWM::InputField"
+  end
+
+  describe Y2Partitioner::Widgets::MountBy do
+    include_examples "CWM::CustomWidget"
+    include_examples "CWM::AbstractWidget#init#store"
+  end
+
+  describe Y2Partitioner::Widgets::GeneralOptions do
+    include_examples "CWM::CustomWidget"
+  end
+
+  describe Y2Partitioner::Widgets::Noauto do
+    include_examples "FstabCheckBox"
+  end
+
+  describe Y2Partitioner::Widgets::ReadOnly do
+    include_examples "FstabCheckBox"
+  end
+
+  describe Y2Partitioner::Widgets::Noatime do
+    include_examples "FstabCheckBox"
+  end
+
+  describe Y2Partitioner::Widgets::MountUser do
+    include_examples "FstabCheckBox"
+  end
+
+  describe Y2Partitioner::Widgets::Quota do
+    include_examples "CWM::CheckBox"
+  end
+
+  describe Y2Partitioner::Widgets::JournalOptions do
+    include_examples "CWM::ComboBox"
+    include_examples "CWM::AbstractWidget#init#store"
+  end
+
+  describe Y2Partitioner::Widgets::AclOptions do
+    include_examples "CWM::CustomWidget"
+  end
+
+  describe Y2Partitioner::Widgets::ArbitraryOptions do
+    include_examples "CWM::InputField"
+  end
+
+  describe Y2Partitioner::Widgets::FilesystemsOptions do
+    include_examples "CWM::CustomWidget"
+  end
+
+  describe Y2Partitioner::Widgets::SwapPriority do
+    include_examples "CWM::InputField"
+  end
+
+  describe Y2Partitioner::Widgets::IOCharset do
+    include_examples "CWM::ComboBox"
+    include_examples "CWM::AbstractWidget#init#store"
+  end
+
+  describe Y2Partitioner::Widgets::Codepage do
+    include_examples "CWM::ComboBox"
+    include_examples "CWM::AbstractWidget#init#store"
+  end
+end

--- a/test/widgets/partition_page_test.rb
+++ b/test/widgets/partition_page_test.rb
@@ -4,7 +4,7 @@ require "cwm/rspec"
 require "y2partitioner/widgets/partition_page"
 
 describe Y2Partitioner::Widgets::PartitionPage do
-  let(:partition) { double("Partition", name: "/dev/hdz1") }
+  let(:partition) { double("Partition", name: "/dev/hdz1", basename: "hdz1") }
 
   subject { described_class.new(partition) }
 


### PR DESCRIPTION
(This is a continuation of #18 in the shared repo)

In progress ... more testing, <s>role dialog</s>, and some fixes when some options is selected as for example set fstab default options for the filesystem selected, offer only the filesystems allowed for a specific partition and more disabling/enabling checks.

## Edit Partitioning Dialog
![screenshot from 2017-06-27 14-18-25](https://user-images.githubusercontent.com/7056681/27589581-d7ec513a-5b43-11e7-98fd-f5485530657a.png)

## Fstab Options Dialog
![screenshot from 2017-06-27 14-18-29](https://user-images.githubusercontent.com/7056681/27589580-d7e76c24-5b43-11e7-9682-a77357a64e31.png)

## Fstab Help Dialog
![screenshot from 2017-06-27 14-19-47](https://user-images.githubusercontent.com/7056681/27589579-d7e45f02-5b43-11e7-9d08-1a66d8c91738.png)

